### PR TITLE
Add field-based paper network layout

### DIFF
--- a/ui/paper_network.py
+++ b/ui/paper_network.py
@@ -1,10 +1,24 @@
 # ui/paper_network_and_basic_info.py
 import streamlit as st
 from utils import cytoscape_utils
+from utils import field_colors
 from st_cytoscape import cytoscape
 
 def render_network_sections(papers, details=False):
-    elements = cytoscape_utils.build_cy_elements_simple(papers)
+    analysis_map = {}
+    all_analyzed = True
+    for paper in papers.papers:
+        key = f"paper_analysis_{paper.paper_id}"
+        analysis = st.session_state.get(key)
+        if analysis:
+            analysis_map[paper.paper_id] = analysis
+        else:
+            all_analyzed = False
+
+    if all_analyzed and analysis_map:
+        elements = cytoscape_utils.build_cy_elements_by_field(papers, analysis_map)
+    else:
+        elements = cytoscape_utils.build_cy_elements_simple(papers)
     style_sheet = [
         {
             "selector": "node",
@@ -12,9 +26,10 @@ def render_network_sections(papers, details=False):
                 "label": "data(label)",
                 "font-size": "12px",
                 "color": "#333",
+                "background-color": "data(color)",
                 "width": "30px",
                 "height": "30px",
-            }
+            },
         },
         {
             "selector": "edge",
@@ -33,6 +48,14 @@ def render_network_sections(papers, details=False):
                 "border-color": "#F00",
                 "border-width": "2px",
             }
+        },
+        {
+            "selector": "[type='field']",
+            "style": {"shape": "rectangle", "width": "40px", "height": "40px"},
+        },
+        {
+            "selector": "[type='paper']",
+            "style": {"shape": "ellipse"},
         },
     ]
     layout = {"name": "preset"}

--- a/utils/cytoscape_utils.py
+++ b/utils/cytoscape_utils.py
@@ -1,4 +1,6 @@
 import math
+from collections import defaultdict
+from . import field_colors
 
 def build_cy_elements_simple(papers: list) -> list:
     """
@@ -59,6 +61,78 @@ def build_cy_elements_simple(papers: list) -> list:
         }
         elements.append(edge)
     
+    return elements
+
+
+def build_cy_elements_by_field(papers, analysis_map):
+    """Create Cytoscape elements grouped by field.
+
+    Parameters
+    ----------
+    papers : PaperResult
+        Search result papers.
+    analysis_map : dict
+        Mapping from paper_id to PaperAnalysisResult.
+    """
+    elements = []
+
+    center_node = {"data": {"id": "center", "label": "your paper", "type": "center"}, "position": {"x": 0, "y": 0}}
+    elements.append(center_node)
+
+    # Group papers by their main field (first in list)
+    field_groups = defaultdict(list)
+    for paper in papers.papers:
+        analysis = analysis_map.get(paper.paper_id)
+        if not analysis or not analysis.fields:
+            field_groups["Unknown"].append(paper)
+            continue
+        main_field = analysis.fields[0].name
+        field_groups[main_field].append(paper)
+
+    num_fields = len(field_groups)
+    radius = 150
+    angle_step = 2 * math.pi / num_fields if num_fields else 0
+
+    for idx, (field, plist) in enumerate(field_groups.items()):
+        angle = idx * angle_step
+        fx = radius * math.cos(angle)
+        fy = radius * math.sin(angle)
+        field_id = f"field_{idx}"
+        field_node = {
+            "data": {
+                "id": field_id,
+                "label": field,
+                "type": "field",
+                "color": field_colors.get_field_color(field),
+            },
+            "position": {"x": fx, "y": fy},
+        }
+        elements.append(field_node)
+        elements.append({"data": {"id": f"edge_center_{field_id}", "source": "center", "target": field_id}})
+
+        sub_radius = 70
+        sub_angle = 2 * math.pi / len(plist) if plist else 0
+        for j, paper in enumerate(plist):
+            px = fx + (sub_radius + j * 10) * math.cos(j * sub_angle)
+            py = fy + (sub_radius + j * 10) * math.sin(j * sub_angle)
+            node_id = f"paper_{paper.paper_id}"
+            node = {
+                "data": {
+                    "id": node_id,
+                    "paper_id": paper.paper_id,
+                    "label": paper.title,
+                    "title": paper.title,
+                    "abstract": paper.abstract,
+                    "url": paper.url,
+                    "color": field_colors.get_field_color(field),
+                    "type": "paper",
+                    "relatedness": j + 1,
+                },
+                "position": {"x": px, "y": py},
+            }
+            elements.append(node)
+            elements.append({"data": {"id": f"edge_{field_id}_{node_id}", "source": field_id, "target": node_id}})
+
     return elements
 
 # テスト用のサンプルデータ（与えられた例）


### PR DESCRIPTION
## Summary
- restructure network layout using paper analysis fields
- color nodes by field and adjust styling

## Testing
- `python -m py_compile utils/cytoscape_utils.py ui/paper_network.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418b0028c0832ca3cd76bfddf4155b