### PR TITLE
Streamlit app のollama API設定を整理

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ paper_search/
 │           └── main.tsx
 └── streamlit_app
     ├── Dockerfile
+    ├── README.md
     ├── api
     │   ├── lm_studio_api.py
     │   ├── ollama_api.py

--- a/README.md
+++ b/README.md
@@ -39,24 +39,26 @@
    しています。`pip install` で不足がある場合は適宜追加してください。
 2. 必要に応じて環境変数 `OLLAMA_MODEL` を設定します。未設定の場合は
    `gemma-textonly_v3:latest` が使用されます。
-3. Ollama API の接続先を変更したい場合は環境変数 `OLLAMA_API_BASE_URL`
-   を設定します。Docker 実行時は `http://host.docker.internal:11435` が
-   自動で使用され、ネイティブ環境では `http://127.0.0.1:11435` が
-   既定値となります。
+3. Ollama API の接続先は実行環境から自動で判定されます。
+   Docker コンテナ内では `http://host.docker.internal:11435`、
+   ネイティブ環境では `http://127.0.0.1:11435` が既定値となるため、
+   環境変数 `OLLAMA_API_BASE_URL` を設定する必要はありません。
+   別のエンドポイントを利用したい場合のみこの環境変数を指定してください。
 4. 以下のコマンドでアプリを起動します。
    ```bash
    streamlit run streamlit_app/app.py
    ```
 
-### Ollama API 接続先の変更例
-`.env` ファイルに以下のように記述すると、API エンドポイントを簡単に切り替えられます。
+### Ollama API 接続先を手動で変更したい場合
+通常は自動判定されますが、`.env` ファイルに以下のように記述することで
+任意のエンドポイントを指定できます。
 
 ```env
 OLLAMA_API_BASE_URL=http://host.docker.internal:11435
 ```
 
-Docker 起動時は上記の値が自動で設定されています。ネイティブ環境で起動する場合は
-`http://127.0.0.1:11435` など実際の Ollama のホストを指定してください。
+値を指定しない場合は、Docker 実行時は `http://host.docker.internal:11435`、
+ネイティブ環境では `http://127.0.0.1:11435` が自動で使用されます。
 
 ## 今後追加したい機能とそれに対する展望
 - 既に解析した論文を保存しておく機能。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     ports:
       - "8501:8501"
     container_name: streamlit_app
-    environment:
-      - OLLAMA_API_BASE_URL=http://host.docker.internal:11435
     extra_hosts:
       - host.docker.internal:host-gateway
   backend:

--- a/project_export.md
+++ b/project_export.md
@@ -1,5 +1,7 @@
-Markdown export complete: project_export.md
-h/
+## プロジェクト構成
+
+```
+paper_search/
 ├── AGENTS.md
 ├── docker-compose.yml
 ├── react_app
@@ -73,6 +75,7 @@ paper_search/
 │           └── main.tsx
 └── streamlit_app
     ├── Dockerfile
+    ├── README.md
     ├── api
     │   ├── lm_studio_api.py
     │   ├── ollama_api.py
@@ -128,8 +131,6 @@ services:
     ports:
       - "8501:8501"
     container_name: streamlit_app
-    environment:
-      - OLLAMA_API_BASE_URL=http://host.docker.internal:11435
     extra_hosts:
       - host.docker.internal:host-gateway
   backend:
@@ -149,80 +150,6 @@ services:
 
 ```
 
-### File: react_app/backend/Dockerfile
-
-```
-FROM python:3.10-slim
-WORKDIR /app
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-COPY . /app
-EXPOSE 8000
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
-
-```
-
-### File: react_app/backend/main.py
-
-```python
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-
-app = FastAPI()
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-@app.get("/health")
-async def health_check():
-    """ヘルスチェック用エンドポイント"""
-    return {"status": "ok"}
-
-
-```
-
-### File: react_app/backend/requirements.txt
-
-```
-fastapi
-uvicorn
-
-```
-
-### File: react_app/frontend/Dockerfile
-
-```
-FROM node:18
-WORKDIR /app
-COPY package.json ./
-RUN npm install
-COPY . /app
-EXPOSE 5173
-CMD ["npm", "run", "dev", "--", "--host"]
-
-```
-
-### File: react_app/frontend/src/main.tsx
-
-```
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-
-const App = () => <div>Paper Search Frontend</div>;
-
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
-
-```
-
 ### File: streamlit_app/Dockerfile
 
 ```
@@ -230,7 +157,6 @@ FROM python:3.10-slim
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-ENV OLLAMA_API_BASE_URL=http://host.docker.internal:11435
 COPY . /app
 EXPOSE 8501
 CMD ["streamlit", "run", "app.py", "--server.address=0.0.0.0", "--server.port=8501"]
@@ -453,121 +379,6 @@ python-dotenv
 
 ```
 
-### File: streamlit_app/state/__init__.py
-
-```python
-
-```
-
-### File: streamlit_app/state/state_manager.py
-
-```python
-# state/state_manager.py
-
-import streamlit as st
-from core.data_models import PaperResult, PaperAnalysisResult
-from utils import config
-
-def initialize_session_state():
-    defaults = {
-        "search_mode": "キーワード検索",
-        "first_user_input": "",
-        "papers": PaperResult(),
-        "user_input_analysis": None,
-        "paper_analysis": None,
-        "num_search_papers": 10,
-        "year_range": (2023, 2025),
-        "search_engine": "semantic scholar",
-        "selected_paper": [],
-        "prev_selected_nodes": [],
-        "chat_history": [{"role": "system", "content": config.system_prompt}],
-        "initial_prompt_processed": True,
-    }
-
-    for key, value in defaults.items():
-        if key not in st.session_state:
-            st.session_state[key] = value
-
-def reset_chat_history():
-    st.session_state["chat_history"] = [{"role": "system", "content": config.system_prompt}]
-    st.session_state["initial_prompt_processed"] = False
-
-def update_selected_paper(selected_paper):
-    st.session_state["selected_paper"] = selected_paper
-    #st.session_state["initial_prompt_processed"] = False
-
-def update_paper_results(papers: PaperResult):
-    st.session_state["papers"] = papers
-
-def update_user_input_analysis(analysis: PaperAnalysisResult):
-    """
-    analysis情報を
-    user_input_analysis
-    に保存
-    """
-    st.session_state["user_input_analysis"] = analysis
-
-def update_user_results(analysis: PaperAnalysisResult):
-    """
-    analysis情報を
-    paper_analysis
-    に保存
-    """
-    st.session_state["paper_analysis"] = analysis
-
-def update_search_settings(num_search_papers: int, year_range: tuple, search_engine: str):
-    st.session_state["num_search_papers"] = num_search_papers
-    st.session_state["year_range"] = year_range
-    st.session_state["search_engine"] = search_engine
-
-```
-
-### File: streamlit_app/state/state_manager_back.py
-
-```python
-# state_manager.py
-import streamlit as st
-#from utils.paper_controller import PaperResult
-from core.data_models import PaperResult
-from utils.llm_controller import PaperAnalysisResult
-from utils import config
-
-def initialize_session_state():
-    # 検索モードと入力値
-    if "search_mode" not in st.session_state:
-        st.session_state["search_mode"] = "キーワード検索"
-    if "first_user_input" not in st.session_state:
-        st.session_state["first_user_input"] = ""
-    
-    # 論文検索結果
-    if "papers" not in st.session_state:
-        st.session_state["papers"] = PaperResult()
-    
-    # ユーザー入力解析結果
-    if "user_input_analysis" not in st.session_state:
-        st.session_state["user_input_analysis"] = None
-
-    # 検索に関するオプション
-    if "num_search_papers" not in st.session_state:
-        st.session_state["num_search_papers"] = 10
-    if "year_range" not in st.session_state:
-        st.session_state["year_range"] = (2023, 2025)
-    if "search_engine" not in st.session_state:
-        st.session_state["search_engine"] = "semantic scholar"
-
-    # ネットワークで選択された論文
-    if "selected_paper" not in st.session_state:
-        st.session_state["selected_paper"] = []
-
-    # 論文表示のための1つ前の論文保存用
-    if "prev_selected_nodes" not in st.session_state:
-        st.session_state["prev_selected_nodes"] = []
-
-    if "chat_history" not in st.session_state:
-        st.session_state["chat_history"] = [{"role": "system", "content": config.system_prompt}]
-        st.session_state["initial_prompt_processed"] = True
-```
-
 ### File: streamlit_app/core/__init__.py
 
 ```python
@@ -695,6 +506,724 @@ def fetch_papers_by_query(query: str, year_range: Tuple[int, int], limit: int = 
     ]
     return PaperResult(papers=papers)
 
+```
+
+### File: streamlit_app/ui/__init__.py
+
+```python
+
+```
+
+### File: streamlit_app/ui/chat_panel.py
+
+```python
+# テキストチャット
+import streamlit as st
+from utils import llm_controller, config
+from api import lm_studio_api, ollama_api
+
+def render_history(chat_history, css_text_user, css_text_assistant):
+    """
+    チャット履歴をHTML形式でレンダリングする。
+    """
+    out = ""
+    script = """<script>
+        var chatBoxes = document.getElementsByClassName("chat-box");
+        if (chatBoxes.length > 0) {
+            chatBoxes[chatBoxes.length - 1].scrollTop = chatBoxes[chatBoxes.length - 1].scrollHeight;
+        }
+    </script>"""
+    for msg in chat_history:
+        if msg["role"] == "assistant":
+            out += f"""{css_text_assistant}<strong>Assistant:</strong> {msg['content']}</div>{script}\n\n"""
+        elif msg["role"] == "user":
+            out += f"""{css_text_user}<strong>User:</strong> {msg['content']}</div>{script}\n\n"""
+    return out
+
+def update_chat_history_with_response(api_messages, stream_placeholder):
+    """
+    LLM APIからのストリーミングレスポンスを処理し、チャット履歴を更新する。
+    """
+    #MODEL = config.OLLAMA_MODEL
+    MODEL = "gemma3:12b"
+    #MODEL = "deepseek-r1:8b-0528-qwen3-q8_0"
+    assistant_response = ""
+    #stream_placeholder = st.empty()  # ストリーミング更新用プレースホルダー
+    for updated_text in ollama_api.stream_chat_response(model_name=MODEL,messages=api_messages):
+        assistant_response = updated_text
+        stream_placeholder.markdown(f"<strong>Assistant:</strong> {updated_text}</div>", unsafe_allow_html=True)
+    stream_placeholder.empty()
+    st.session_state["chat_history"].append({
+        "role": "assistant",
+        "content": assistant_response
+    })
+    return assistant_response
+
+def render_stream(stream_placeholder, selected_paper):
+    selected_paper_content = f"{selected_paper['title']}, {selected_paper['abstract']}"
+    if st.session_state["search_mode"] == "AI検索 2":
+        initial_prompt = (
+            f"{config.INST_PROMPT_AI}\nユーザー論文:{st.session_state['first_user_input']}"
+            f"\"\"\"選択された論文\"\"\"{selected_paper_content}\"\"\""
+        )
+    elif st.session_state["search_mode"] == "キーワード検索":
+        initial_prompt = (
+            f"{config.INST_PROMPT_KEYWORDS}\n"
+            f"検索キーワード：{st.session_state['first_user_input']}\n論文：{selected_paper_content}"
+        )
+    else:
+        st.error("検索方法が指定されていないことになっています。")
+        return
+
+    st.session_state["chat_history"].append({
+        "role": "hidden_user",
+        "content": initial_prompt
+    })
+
+    # hidden_user を user に変換した API 用メッセージリストの作成
+    api_messages = [
+        {"role": "user" if msg["role"] == "hidden_user" else msg["role"], "content": msg["content"]}
+        for msg in st.session_state["chat_history"]
+    ]
+    update_chat_history_with_response(api_messages, stream_placeholder)
+
+        
+```
+
+### File: streamlit_app/ui/paper_network.py
+
+```python
+# ui/paper_network_and_basic_info.py
+import streamlit as st
+from utils import cytoscape_utils
+from utils import field_colors
+from st_cytoscape import cytoscape
+
+def render_network_sections(papers, details=False):
+    analysis_map = {}
+    all_analyzed = True
+    for paper in papers.papers:
+        key = f"paper_analysis_{paper.paper_id}"
+        analysis = st.session_state.get(key)
+        if analysis:
+            analysis_map[paper.paper_id] = analysis
+        else:
+            all_analyzed = False
+
+    if all_analyzed and analysis_map:
+        elements = cytoscape_utils.build_cy_elements_by_field(papers, analysis_map)
+    else:
+        elements = cytoscape_utils.build_cy_elements_simple(papers)
+    style_sheet = [
+        {
+            "selector": "node",
+            "style": {
+                "label": "data(label)",
+                "font-size": "10px",
+                "color": "#333",
+                "background-color": "data(color)",
+                "width": "35px",
+                "height": "35px",
+            },
+        },
+        {
+            "selector": "edge",
+            "style": {
+                "width": 2,
+                "line-color": "#ccc",
+                "target-arrow-shape": "triangle",
+                "target-arrow-color": "#ccc",
+                "curve-style": "bezier",
+            }
+        },
+        {
+            "selector": "node:selected",
+            "style": {
+                "background-color": "#FF0000",
+                "border-color": "#F00",
+                "border-width": "2px",
+            }
+        },
+        {
+            "selector": "[type='field']",
+            "style": {"shape": "rectangle", "width": "50px", "height": "50px"},
+        },
+        {
+            "selector": "[type='subfield']",
+            "style": {"shape": "round-rectangle", "width": "45px", "height": "45px"},
+        },
+        {
+            "selector": "[type='paper']",
+            "style": {"shape": "ellipse", "width": "35px", "height": "35px"},
+        },
+    ]
+    layout = {"name": "preset"}
+    
+    with st.container():
+        selected = cytoscape(
+            elements,
+            style_sheet,
+            height="800px",
+            layout=layout,
+            key="graph",
+            selection_type="single",
+            min_zoom=0.5,
+            max_zoom=1
+        )
+    # ノード情報の高速検索用辞書（センター以外）
+    element_dict = {str(f"{e['data']['id']}"): e for e in elements if e["data"]["id"] != "center"}
+    # 論文情報を paper_id でマッピング（ここでは PaperFields の paper_id と対応付け）
+    papers_dict = {str(f"paper_{p.paper_id}"): p for p in papers.papers}
+    
+    return selected, element_dict, papers_dict
+
+def get_selected_papers(selected, element_dict, papers_dict):
+    """
+    選択されたノードから論文情報のリストを作成する関数
+    """
+    selected_papers = []
+    if selected and "nodes" in selected:
+        for node_id in selected["nodes"]:
+            if node_id == "center":
+                continue
+            node_papers = papers_dict.get(node_id)
+            node_elem = element_dict.get(node_id)
+            if not node_papers:
+                print("why")
+                continue
+            selected_papers.append({
+                "title": node_papers.title,
+                "abstract": node_papers.abstract,
+                "url": node_papers.url,
+                "paper_id": node_papers.paper_id,
+                "relatedness": node_elem["data"]["relatedness"],
+            #    "relatedness": getattr(paper, "relatedness", 0),  # 存在しない場合は0とする例
+            #    "university": getattr(paper, "university", "不明"),
+            #    "url": paper.url,
+            #    "abstract": paper.abstract,
+            })
+    return selected_papers
+```
+
+### File: streamlit_app/ui/result_summary.py
+
+```python
+# ui/result_summary.py
+import streamlit as st
+import plotly.express as px
+import pandas as pd
+from utils.field_colors import get_field_color
+
+def render__paper_info_analysis(fields):
+    if not fields:
+        st.warning("データがありません。")
+        return
+
+    total_score = sum(field.score for field in fields)
+    data = [
+        {"name": field.name, "score": field.score, "percentage": 100 * field.score / total_score}
+        for field in fields
+    ]
+    df = pd.DataFrame(data).copy().sort_values("percentage", ascending=False)
+    sorted_names = df["name"].tolist()
+
+    color_map = {name: get_field_color(name) for name in df["name"]}
+
+    fig = px.pie(
+        df,
+        names="name",
+        values="percentage",
+        title="各分野の割合（多い順・時計回り）",
+        category_orders={"name": sorted_names},
+        color="name",
+        color_discrete_map=color_map,
+    )
+    fig.update_traces(direction="clockwise")
+    st.plotly_chart(fig, use_container_width=True)
+
+def render_paper_analysis_result(result):
+    data = {}
+    if result.title:
+        data["タイトル"] = result.title
+    if result.fields:
+        data["分野"] = ", ".join([f"{field.name} ({field.score})" for field in result.fields])
+    if result.target:
+        data["対象"] = result.target.ja
+    if result.methods:
+        data["手法"] = ", ".join([label.ja for label in result.methods])
+    if result.factors:
+        data["要因"] = ", ".join([label.ja for label in result.factors])
+    if result.metrics:
+        data["指標"] = ", ".join([label.ja for label in result.metrics])
+    if result.search_keywords:
+        data["検索キーワード"] = ", ".join([label.ja for label in result.search_keywords])
+    if result.main_keywords:
+        data["主要キーワード"] = ", ".join([label.ja for label in result.main_keywords])
+    
+    df = pd.DataFrame.from_dict(data, orient="index", columns=["内容"])
+    st.table(df)
+
+def render_info_paper(papers):
+    for paper in papers:
+        st.write(f"タイトル: {paper['title']}")
+        st.write(f"関連順位: {paper.get('relatedness', 0)} 位")
+        st.write(f"URL: {paper['url']}")
+        st.write(f"アブストラクト：\n {paper['abstract']}")
+        st.write("---")
+
+```
+
+### File: streamlit_app/ui/search_bar.py
+
+```python
+# ui/search_bar.py
+
+import streamlit as st
+from core import paper_service, llm_service
+from state import state_manager
+
+def render_search_section():
+    st.radio(
+        "検索モード選択:",
+        ("キーワード検索", "AI検索 1", "AI検索 2"),
+        horizontal=True,
+        key="search_mode"
+    )
+
+    st.caption(
+        '※ キーワード検索 : 指定されたキーワードで検索を行います。（例：「genarative ai transformer」）',
+        unsafe_allow_html=True
+    )
+    st.caption(
+        '※ AI検索 1 : 入力された文章から関連度の高い論文を自動で解析し検索します。（例：「～～に関する論文が知りたい」）',
+        unsafe_allow_html=True
+    )
+    st.caption(
+        '※ AI検索 2 : 論文で論文を検索する場合は「(論文タイトル),(論文アブストラクト)」の形式にしてください。',
+        unsafe_allow_html=True
+    )
+
+    input_col, search_button = st.columns([8, 2])
+
+    with input_col:
+        st.text_area("入力:", value="", placeholder="ここに入力...", key="first_user_input")
+
+    with search_button:
+        if st.button("検索実行"):
+            query = st.session_state["first_user_input"]
+            mode = st.session_state["search_mode"]
+            engine = st.session_state["search_engine"]
+            year_range = st.session_state["year_range"]
+            num_papers = st.session_state["num_search_papers"]
+
+            if mode == "キーワード検索":
+                results = paper_service.fetch_papers_by_query(query, year_range, num_papers)
+                state_manager.update_paper_results(results)
+
+            elif mode == "AI検索 2":
+                analysis = llm_service.analyze_user_paper(query)
+                state_manager.update_user_input_analysis(analysis)
+                ai_query = analysis.search_keywords[0].en
+                results = paper_service.fetch_papers_by_query(ai_query, year_range, num_papers)
+                state_manager.update_paper_results(results)
+
+def render_search_info_selection_section():
+    with st.expander("オプション設定"):
+        search_num_col, year_col, search_engine_col = st.columns([1, 1, 1])
+
+        with search_num_col:
+            st.slider(
+                "検索する論文数",
+                1,
+                50,
+                st.session_state["num_search_papers"],
+                key="num_search_papers",
+            )
+        with year_col:
+            st.slider(
+                "発行年の範囲",
+                1970,
+                2025,
+                st.session_state["year_range"],
+                key="year_range",
+            )
+        with search_engine_col:
+            st.radio(
+                "検索エンジン選択:",
+                ("semantic scholar", "Google Scholar"),
+                horizontal=True,
+                key="search_engine",
+            )
+
+
+```
+
+### File: streamlit_app/api/__init__.py
+
+```python
+
+```
+
+### File: streamlit_app/api/lm_studio_api.py
+
+```python
+import json
+from openai import OpenAI
+from utils import config
+
+def get_structured_response(client: OpenAI, model: str, messages: list) -> dict:
+    """
+    lm studio jsonスキーマ固定出力
+    指定したモデルとメッセージでチャット補完を実行し、
+    返ってきたJSON形式のレスポンスを辞書型に変換して返す関数。
+    
+    Parameters:
+        client (OpenAI): OpenAIクライアントインスタンス
+        model (str): 使用するモデル名
+        messages (list): チャットで送信するメッセージのリスト
+    
+    Returns:
+        dict: 整形されたレスポンス（例: fields, labels など）
+    
+    Raises:
+        ValueError: JSONのパースに失敗した場合
+    """
+    response = client.chat.completions.create(
+        model=model,
+        messages=messages,
+        # 必要に応じて追加パラメータを設定
+    )
+    
+
+    # message.content全体を取得
+    result = response.choices[0].message.content
+    clean_lines = [line for line in result.splitlines() if not line.strip().startswith("```")]
+    result = "\n".join(clean_lines)
+    #print(result)
+
+
+    try:
+        structured_data = json.loads(result)
+    except json.JSONDecodeError as e:
+        print(result)
+        raise ValueError("レスポンスのJSON形式に誤りがあります") from e
+
+    return structured_data
+
+def stream_chat_response(messages, temperature=0.2):
+    """
+    APIを呼び出してストリーミング応答を生成するジェネレーター関数
+    """
+    # システムプロンプトやAPI設定
+    system_prompt = "あなたは誠実で優秀な日本人のアシスタントです。特に指示が無い場合は、常に日本語で回答してください。"
+    url1 = "http://192.168.11.26:1234/v1"
+    client = OpenAI(base_url=url1, api_key="lm-studio")
+    MODEL = "my-model"
+    stream = client.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        stream=True,
+        #temperature=temperature
+    )
+    response_text = ""
+    for chunk in stream:
+        delta = chunk.choices[0].delta
+        if delta.content:
+            response_text += delta.content
+            yield response_text
+
+
+# 使用例
+if __name__ == "__main__":
+    client = OpenAI(base_url="http://192.168.11.26:1234/v1", api_key="lm-studio")
+    #client = OpenAI(base_url="http://localhost:11435/v1", api_key="gemma3:12b")
+    
+    #MODEL = "gemma3:12b"
+    MODEL = "my-model"
+    #MODEL = "gemma-3-12b-it@q3_k_l"
+    user_paper = '''"""感度解析を介した時系列遺伝子発現データ補完法の開発と創薬応用,承認薬を含む生物活性化合物は治療標的となるタンパク質に作用することで疾患治療のための作用を示す。しか し、それ以外のタンパク質に作用することで副作用のような期待していない作用を示す場合がある。したがって、 化合物の作用メカニズムを明らかにすることは、創薬における重要課題になっている。近年、オミクス情報に基づく、化合物の作用メカニズム予測が注目されている。例えば、化合物をヒト由来細胞に 添加して、一定時間後に遺伝子発現を観測した、化合物応答遺伝子発現データは、化合物の作用メカニズムの予測 に用いられている。しかしながら、このような遺伝子発現データは、コストや時間の制約により、特定の時間点で のみ観測され時系列で観測されていない。これによって、特定の時間点での解析を行うことはできるが、経時的に 解析を行うことができない。したがって、現状のデータから、化合物の経時的な影響を予測することは限界がある。そこで本研究では、細胞内システムに対して構築された数理モデルの感度解析を行い、得られた結果に基づき、 観測されている化合物応答遺伝子発現データから、時系列の遺伝子発現データを補完する新たな手法を開発することを目指した。"""'''
+    user_paper = '''"""多次元センサデータ処理のためのTransformerを用いた自己教師あり学習手法,センサ信号を入力として,人間行動認識を行う深層学習アルゴリズムを開発した. ここでは自然言語で用いられるTransformerに基づいた事前学習言語モデルを構築して, その事前学習言語モデルを用いて,下流タスクである人間行動認識タスクを解く形を追求する. VanillaのTransformerでもこれは可能であるが, ここでは, 線形層によるn次元数値データの埋め込み、ビン化処理、出力層の線形処理層という３つの要素を特色とするｎ次元数値処理トランスフォーマーを提案する。5種類のデータセットに対して、このモデルの効果を確かめた. VanillaのTransformerと比較して, 精度で10%～15%程度, 向上させることができた"""'''
+    #user_paper = '''"""P2LHAP: Wearable-Sensor-Based Human Activity Recognition, Segmentation, and Forecast Through Patch-to-Label Seq2Seq Transformer Traditional deep learning methods struggle to simultaneously segment, recognize, and forecast human activities from sensor data. This limits their usefulness in many fields, such as healthcare and assisted living, where real-time understanding of ongoing and upcoming activities is crucial. This article introduces P2LHAP, a novel Patch-to-Label Seq2Seq framework that tackles all three tasks in an efficient single-task model. P2LHAP divides sensor data streams into a sequence of “patches,” served as input tokens, and outputs a sequence of patch-level activity labels, including the predicted future activities. A unique smoothing technique based on surrounding patch labels, is proposed to identify activity boundaries accurately. Additionally, P2LHAP learns patch-level representation by sensor signal channel-independent Transformer encoders and decoders. All channels share embedding and Transformer weights across all sequences. Evaluated on the three public datasets, P2LHAP significantly outperforms the state-of-the-art in all three tasks, demonstrating its effectiveness and potential for real-world applications."""'''
+    messages = [
+        {
+            "role": "user",
+            "content": config.experiment_message_without_paper + user_paper
+        }
+    ]
+    
+    data = get_structured_response(client, MODEL, messages)
+    print(data)
+    print(data.keys())
+    #for item in data['fields']:
+    #    print(f"{item['name']}:{item['score']}")
+
+```
+
+### File: streamlit_app/api/ollama_api.py
+
+```python
+import requests
+import json
+from utils import config
+from jsonschema import validate, ValidationError
+
+def get_structured_response(model_name: str, prompt: str, temperature: float = 0.8, max_tokens: int = 500) -> dict:
+    """
+    Ollama の /api/generate エンドポイントを使い、指定したプロンプトで生成を実行します。
+    非ストリーミングのため、レスポンス全体を一度に取得して辞書型に変換します。
+    """
+    url_generate = config.OLLAMA_GENERATE_URL
+    data = {
+        "model": model_name,
+        "prompt": prompt,
+        "stream": False,
+        "temperature": temperature,
+        #"max_tokens": max_tokens
+    }
+    response = requests.post(url_generate, json=data)
+    if response.status_code != 200:
+        raise Exception(f"Error: {response.status_code}")
+    
+    result = response.text
+    # 不要なマークダウン（例: ```）が含まれている場合は除去
+    clean_lines = [line for line in result.splitlines() if not line.strip().startswith("```")]
+    clean_result = "\n".join(clean_lines)
+    
+    try:
+        structured_data = json.loads(clean_result)
+    except json.JSONDecodeError as e:
+        raise ValueError("レスポンスのJSON形式に誤りがあります.1") from e
+    
+    # 不要なマークダウン（例: ```）が含まれている場合は除去
+    clean_lines = [line for line in structured_data["response"].splitlines() if not line.strip().startswith("```")]
+    clean_result = "\n".join(clean_lines)
+
+    try:
+        structured_data = json.loads(clean_result)
+    except json.JSONDecodeError as e:
+        print(clean_result)
+        raise ValueError("レスポンスのJSON形式に誤りがあります.2") from e
+
+    return structured_data
+
+def get_structured_response_v2(model_name: str, prompt: str, temperature: float = 0.8, max_tokens: int = 500, json_schema: dict = config.structured_json_schema) -> dict:
+    """
+    Structured output機能を利用して、JSONスキーマに沿ったレスポンスを取得する改良版関数です。
+    
+    Parameters:
+        model_name (str): 使用するモデル名
+        prompt (str): ユーザーのプロンプト
+        temperature (float): 出力の多様性を制御するパラメータ
+        max_tokens (int): 最大トークン数（必要に応じて利用）
+        json_schema (dict): JSONスキーマを指定する場合に渡す。例:
+            {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "capital": { "type": "string" },
+                "languages": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              },
+              "required": ["name", "capital", "languages"]
+            }
+    
+    Returns:
+        dict: 解析済みの構造化されたレスポンス
+    """
+    url_chat = config.OLLAMA_CHAT_URL  # エンドポイントをchatに変更
+    payload = {
+        "model": model_name,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+        "temperature": temperature,
+    }
+    if json_schema:
+        payload["format"] = json_schema
+
+    response = requests.post(url_chat, json=payload)
+    if response.status_code != 200:
+        raise Exception(f"Error: {response.status_code}")
+    
+    result = response.text
+    
+    
+    try:
+        structured_data = json.loads(result)
+        print("\n\n",structured_data)
+    except json.JSONDecodeError as e:
+        raise ValueError("レスポンスのJSON形式に誤りがあります") from e
+    
+    try:
+        content = structured_data["message"]["content"]
+    except (KeyError, TypeError):
+        raise ValueError("レスポンス形式が想定と異なります")
+    
+    clean_lines = [line for line in content.splitlines() if not line.strip().startswith("```")]
+    clean_result = "\n".join(clean_lines)
+    
+    try:
+        structured_data = json.loads(clean_result)
+        print("\n\n", structured_data)
+    except json.JSONDecodeError as e:
+        print("abc")
+        print(clean_result)
+        print("def")
+        raise ValueError("レスポンスのJSON形式に誤りがあります.2") from e
+
+    # ここで、json_schema が指定されている場合はバリデーションを実施
+    if json_schema:
+        try:
+            validate(instance=structured_data, schema=json_schema)
+        except ValidationError as ve:
+            raise ValueError("レスポンスが指定されたJSONスキーマに準拠していません。") from ve
+
+    print("last data:\n\n\n\n", structured_data)
+    return structured_data
+
+def stream_chat_response(model_name: str, messages: list, temperature: float = 0.8):
+    """
+    Ollama の /api/chat エンドポイントを使い、ストリーミングでチャット応答を生成するジェネレーター関数です。
+    
+    Parameters:
+        model (str): 使用するモデル名（例: "llama2"）
+        messages (list): 各メッセージに "role" と "content" を含む辞書のリスト
+        temperature (float): 応答の多様性を制御するパラメータ
+    
+    Yields:
+        response_text (str): 累積された応答テキスト（逐次更新）
+    """
+    url_chat = config.OLLAMA_CHAT_URL
+    data = {
+        "model": model_name,
+        "messages": messages,
+        "stream": True,
+        "temperature": temperature
+    }
+    response = requests.post(url_chat, json=data, stream=True)
+    if response.status_code != 200:
+        print(f"Error: {response.status_code}")
+        return
+    
+    response_text = ""
+    """for chunk in response.iter_lines():
+        if chunk:
+            # 受信したチャンクは JSON ではなくプレーンなテキストとして返ってくる前提
+            text = chunk.decode("utf-8")
+            print(text, end="", flush=True)  # 改行せずにリアルタイム出力
+            response_text += text
+            yield response_text"""
+
+    for line in response.iter_lines():
+        if line:
+            try:
+                # 各チャンクは JSON 形式で送られてくると想定
+                chunk = json.loads(line.decode("utf-8"))
+                # 実際のレスポンス構造に合わせてキーを変更してください
+                # ここでは例として、"message" キーの中の "content" を取り出しています
+                content = ""
+                if "message" in chunk and "content" in chunk["message"]:
+                    content = chunk["message"]["content"]
+                else:
+                    # 例外対応: "text" キーの場合
+                    content = chunk.get("text", "")
+                if content:
+                    print(content, end="", flush=True)
+                    response_text += content
+                    yield response_text
+            except json.JSONDecodeError:
+                # JSONパースに失敗した場合、デコード済みの文字列をそのまま出力
+                decoded_line = line.decode("utf-8")
+                print(decoded_line, end="", flush=True)
+                response_text += decoded_line
+                yield response_text
+
+if __name__ == "__main__":
+    # 非ストリーミング生成の例
+    model = config.OLLAMA_MODEL
+    prompt = "自己紹介をお願いします"
+    try:
+        structured_response = get_structured_response(model, prompt)
+        print("Structured response:")
+        print(structured_response)
+    except Exception as e:
+        print("Error:", e)
+    
+    """# ストリーミングチャットの例
+    messages = [
+        { "role": "system", "content": "あなたは親切なアシスタントです" },
+        { "role": "user", "content": "こんにちは" },
+        { "role": "assistant", "content": "はい、何かお手伝いできることはありますか？" },
+        { "role": "user", "content": "天気について教えてください" }
+    ]
+    print("\nStreaming chat response:")
+    for full_response in stream_chat_response(model, messages):
+        # リアルタイムにコンソールへ出力されるので、ここでの処理は不要
+        pass
+"""
+```
+
+### File: streamlit_app/api/paper_api.py
+
+```python
+import requests
+import streamlit as st
+import time
+
+def search_papers_semantic(query: str, year_from: int = 2023,year_to: int = None, limit: int = 20, max_retries=10) -> list[dict]:
+    """
+    指定されたクエリでSemantic Scholar APIから論文情報を取得し、辞書のリストを返す関数。
+
+    Args:
+        query (str): 検索クエリ
+        year_from (int): 取得する論文の開始年（例: 2023）
+        limit (int): 取得件数の上限（最大1000件）
+
+    Returns:
+        list[dict]: 論文情報の辞書のリスト
+    """
+    url = "http://api.semanticscholar.org/graph/v1/paper/search/"
+    query_params = {
+        "query": query,
+        "fields": "title,abstract,url,publicationTypes",
+        #"year": f"{year_from}-",
+        "limit": limit,
+        "sort": "relevance",
+    }
+    if year_to is not None:
+        query_params["year"] = f"{year_from}-{year_to}"
+    else:
+        query_params["year"] = f"{year_from}-"
+
+    retries = 0
+    while retries < max_retries:
+        response = requests.get(url, params=query_params)
+        data = response.json()
+
+        if "data" in data:
+            #st.write(data)
+            return data["data"]
+        elif data.get("code") == "429":
+            st.warning("APIが混雑しています。自動で再試行します...")
+            time.sleep(1)
+            retries += 1
+            continue
+        else:
+            st.error("APIエラーが発生しました。再度検索ボタンを押してください。")
+            st.write(data)
+            return []
+    
+    st.error("APIが混雑しています。時間をおいて再試行してください。")
+        
+
+# 使用例（この行は他ファイルで呼び出す場合の参考）
+# results = search_papers('"human activity recognition sensor transformer"')
+if __name__ == "__main__":
+    query = "Time-Series Gene Expression Data Imputation"
+    data = search_papers_semantic(query=query, year_from=2023, limit=20)
+    print(data)
+    print(len(data))
 ```
 
 ### File: streamlit_app/utils/__init__.py
@@ -1552,721 +2081,192 @@ if __name__ == "__main__":
     print("abstract:", data.paper[0].abstract)
 ```
 
-### File: streamlit_app/ui/__init__.py
+### File: streamlit_app/state/__init__.py
 
 ```python
 
 ```
 
-### File: streamlit_app/ui/chat_panel.py
+### File: streamlit_app/state/state_manager.py
 
 ```python
-# テキストチャット
-import streamlit as st
-from utils import llm_controller, config
-from api import lm_studio_api, ollama_api
-
-def render_history(chat_history, css_text_user, css_text_assistant):
-    """
-    チャット履歴をHTML形式でレンダリングする。
-    """
-    out = ""
-    script = """<script>
-        var chatBoxes = document.getElementsByClassName("chat-box");
-        if (chatBoxes.length > 0) {
-            chatBoxes[chatBoxes.length - 1].scrollTop = chatBoxes[chatBoxes.length - 1].scrollHeight;
-        }
-    </script>"""
-    for msg in chat_history:
-        if msg["role"] == "assistant":
-            out += f"""{css_text_assistant}<strong>Assistant:</strong> {msg['content']}</div>{script}\n\n"""
-        elif msg["role"] == "user":
-            out += f"""{css_text_user}<strong>User:</strong> {msg['content']}</div>{script}\n\n"""
-    return out
-
-def update_chat_history_with_response(api_messages, stream_placeholder):
-    """
-    LLM APIからのストリーミングレスポンスを処理し、チャット履歴を更新する。
-    """
-    #MODEL = config.OLLAMA_MODEL
-    MODEL = "gemma3:12b"
-    #MODEL = "deepseek-r1:8b-0528-qwen3-q8_0"
-    assistant_response = ""
-    #stream_placeholder = st.empty()  # ストリーミング更新用プレースホルダー
-    for updated_text in ollama_api.stream_chat_response(model_name=MODEL,messages=api_messages):
-        assistant_response = updated_text
-        stream_placeholder.markdown(f"<strong>Assistant:</strong> {updated_text}</div>", unsafe_allow_html=True)
-    stream_placeholder.empty()
-    st.session_state["chat_history"].append({
-        "role": "assistant",
-        "content": assistant_response
-    })
-    return assistant_response
-
-def render_stream(stream_placeholder, selected_paper):
-    selected_paper_content = f"{selected_paper['title']}, {selected_paper['abstract']}"
-    if st.session_state["search_mode"] == "AI検索 2":
-        initial_prompt = (
-            f"{config.INST_PROMPT_AI}\nユーザー論文:{st.session_state['first_user_input']}"
-            f"\"\"\"選択された論文\"\"\"{selected_paper_content}\"\"\""
-        )
-    elif st.session_state["search_mode"] == "キーワード検索":
-        initial_prompt = (
-            f"{config.INST_PROMPT_KEYWORDS}\n"
-            f"検索キーワード：{st.session_state['first_user_input']}\n論文：{selected_paper_content}"
-        )
-    else:
-        st.error("検索方法が指定されていないことになっています。")
-        return
-
-    st.session_state["chat_history"].append({
-        "role": "hidden_user",
-        "content": initial_prompt
-    })
-
-    # hidden_user を user に変換した API 用メッセージリストの作成
-    api_messages = [
-        {"role": "user" if msg["role"] == "hidden_user" else msg["role"], "content": msg["content"]}
-        for msg in st.session_state["chat_history"]
-    ]
-    update_chat_history_with_response(api_messages, stream_placeholder)
-
-        
-```
-
-### File: streamlit_app/ui/paper_network.py
-
-```python
-# ui/paper_network_and_basic_info.py
-import streamlit as st
-from utils import cytoscape_utils
-from utils import field_colors
-from st_cytoscape import cytoscape
-
-def render_network_sections(papers, details=False):
-    analysis_map = {}
-    all_analyzed = True
-    for paper in papers.papers:
-        key = f"paper_analysis_{paper.paper_id}"
-        analysis = st.session_state.get(key)
-        if analysis:
-            analysis_map[paper.paper_id] = analysis
-        else:
-            all_analyzed = False
-
-    if all_analyzed and analysis_map:
-        elements = cytoscape_utils.build_cy_elements_by_field(papers, analysis_map)
-    else:
-        elements = cytoscape_utils.build_cy_elements_simple(papers)
-    style_sheet = [
-        {
-            "selector": "node",
-            "style": {
-                "label": "data(label)",
-                "font-size": "10px",
-                "color": "#333",
-                "background-color": "data(color)",
-                "width": "35px",
-                "height": "35px",
-            },
-        },
-        {
-            "selector": "edge",
-            "style": {
-                "width": 2,
-                "line-color": "#ccc",
-                "target-arrow-shape": "triangle",
-                "target-arrow-color": "#ccc",
-                "curve-style": "bezier",
-            }
-        },
-        {
-            "selector": "node:selected",
-            "style": {
-                "background-color": "#FF0000",
-                "border-color": "#F00",
-                "border-width": "2px",
-            }
-        },
-        {
-            "selector": "[type='field']",
-            "style": {"shape": "rectangle", "width": "50px", "height": "50px"},
-        },
-        {
-            "selector": "[type='subfield']",
-            "style": {"shape": "round-rectangle", "width": "45px", "height": "45px"},
-        },
-        {
-            "selector": "[type='paper']",
-            "style": {"shape": "ellipse", "width": "35px", "height": "35px"},
-        },
-    ]
-    layout = {"name": "preset"}
-    
-    with st.container():
-        selected = cytoscape(
-            elements,
-            style_sheet,
-            height="800px",
-            layout=layout,
-            key="graph",
-            selection_type="single",
-            min_zoom=0.5,
-            max_zoom=1
-        )
-    # ノード情報の高速検索用辞書（センター以外）
-    element_dict = {str(f"{e['data']['id']}"): e for e in elements if e["data"]["id"] != "center"}
-    # 論文情報を paper_id でマッピング（ここでは PaperFields の paper_id と対応付け）
-    papers_dict = {str(f"paper_{p.paper_id}"): p for p in papers.papers}
-    
-    return selected, element_dict, papers_dict
-
-def get_selected_papers(selected, element_dict, papers_dict):
-    """
-    選択されたノードから論文情報のリストを作成する関数
-    """
-    selected_papers = []
-    if selected and "nodes" in selected:
-        for node_id in selected["nodes"]:
-            if node_id == "center":
-                continue
-            node_papers = papers_dict.get(node_id)
-            node_elem = element_dict.get(node_id)
-            if not node_papers:
-                print("why")
-                continue
-            selected_papers.append({
-                "title": node_papers.title,
-                "abstract": node_papers.abstract,
-                "url": node_papers.url,
-                "paper_id": node_papers.paper_id,
-                "relatedness": node_elem["data"]["relatedness"],
-            #    "relatedness": getattr(paper, "relatedness", 0),  # 存在しない場合は0とする例
-            #    "university": getattr(paper, "university", "不明"),
-            #    "url": paper.url,
-            #    "abstract": paper.abstract,
-            })
-    return selected_papers
-```
-
-### File: streamlit_app/ui/result_summary.py
-
-```python
-# ui/result_summary.py
-import streamlit as st
-import plotly.express as px
-import pandas as pd
-from utils.field_colors import get_field_color
-
-def render__paper_info_analysis(fields):
-    if not fields:
-        st.warning("データがありません。")
-        return
-
-    total_score = sum(field.score for field in fields)
-    data = [
-        {"name": field.name, "score": field.score, "percentage": 100 * field.score / total_score}
-        for field in fields
-    ]
-    df = pd.DataFrame(data).copy().sort_values("percentage", ascending=False)
-    sorted_names = df["name"].tolist()
-
-    color_map = {name: get_field_color(name) for name in df["name"]}
-
-    fig = px.pie(
-        df,
-        names="name",
-        values="percentage",
-        title="各分野の割合（多い順・時計回り）",
-        category_orders={"name": sorted_names},
-        color="name",
-        color_discrete_map=color_map,
-    )
-    fig.update_traces(direction="clockwise")
-    st.plotly_chart(fig, use_container_width=True)
-
-def render_paper_analysis_result(result):
-    data = {}
-    if result.title:
-        data["タイトル"] = result.title
-    if result.fields:
-        data["分野"] = ", ".join([f"{field.name} ({field.score})" for field in result.fields])
-    if result.target:
-        data["対象"] = result.target.ja
-    if result.methods:
-        data["手法"] = ", ".join([label.ja for label in result.methods])
-    if result.factors:
-        data["要因"] = ", ".join([label.ja for label in result.factors])
-    if result.metrics:
-        data["指標"] = ", ".join([label.ja for label in result.metrics])
-    if result.search_keywords:
-        data["検索キーワード"] = ", ".join([label.ja for label in result.search_keywords])
-    if result.main_keywords:
-        data["主要キーワード"] = ", ".join([label.ja for label in result.main_keywords])
-    
-    df = pd.DataFrame.from_dict(data, orient="index", columns=["内容"])
-    st.table(df)
-
-def render_info_paper(papers):
-    for paper in papers:
-        st.write(f"タイトル: {paper['title']}")
-        st.write(f"関連順位: {paper.get('relatedness', 0)} 位")
-        st.write(f"URL: {paper['url']}")
-        st.write(f"アブストラクト：\n {paper['abstract']}")
-        st.write("---")
-
-```
-
-### File: streamlit_app/ui/search_bar.py
-
-```python
-# ui/search_bar.py
+# state/state_manager.py
 
 import streamlit as st
-from core import paper_service, llm_service
-from state import state_manager
-
-def render_search_section():
-    st.radio(
-        "検索モード選択:",
-        ("キーワード検索", "AI検索 1", "AI検索 2"),
-        horizontal=True,
-        key="search_mode"
-    )
-
-    st.caption(
-        '※ キーワード検索 : 指定されたキーワードで検索を行います。（例：「genarative ai transformer」）',
-        unsafe_allow_html=True
-    )
-    st.caption(
-        '※ AI検索 1 : 入力された文章から関連度の高い論文を自動で解析し検索します。（例：「～～に関する論文が知りたい」）',
-        unsafe_allow_html=True
-    )
-    st.caption(
-        '※ AI検索 2 : 論文で論文を検索する場合は「(論文タイトル),(論文アブストラクト)」の形式にしてください。',
-        unsafe_allow_html=True
-    )
-
-    input_col, search_button = st.columns([8, 2])
-
-    with input_col:
-        st.text_area("入力:", value="", placeholder="ここに入力...", key="first_user_input")
-
-    with search_button:
-        if st.button("検索実行"):
-            query = st.session_state["first_user_input"]
-            mode = st.session_state["search_mode"]
-            engine = st.session_state["search_engine"]
-            year_range = st.session_state["year_range"]
-            num_papers = st.session_state["num_search_papers"]
-
-            if mode == "キーワード検索":
-                results = paper_service.fetch_papers_by_query(query, year_range, num_papers)
-                state_manager.update_paper_results(results)
-
-            elif mode == "AI検索 2":
-                analysis = llm_service.analyze_user_paper(query)
-                state_manager.update_user_input_analysis(analysis)
-                ai_query = analysis.search_keywords[0].en
-                results = paper_service.fetch_papers_by_query(ai_query, year_range, num_papers)
-                state_manager.update_paper_results(results)
-
-def render_search_info_selection_section():
-    with st.expander("オプション設定"):
-        search_num_col, year_col, search_engine_col = st.columns([1, 1, 1])
-
-        with search_num_col:
-            st.slider(
-                "検索する論文数",
-                1,
-                50,
-                st.session_state["num_search_papers"],
-                key="num_search_papers",
-            )
-        with year_col:
-            st.slider(
-                "発行年の範囲",
-                1970,
-                2025,
-                st.session_state["year_range"],
-                key="year_range",
-            )
-        with search_engine_col:
-            st.radio(
-                "検索エンジン選択:",
-                ("semantic scholar", "Google Scholar"),
-                horizontal=True,
-                key="search_engine",
-            )
-
-
-```
-
-### File: streamlit_app/api/__init__.py
-
-```python
-
-```
-
-### File: streamlit_app/api/lm_studio_api.py
-
-```python
-import json
-from openai import OpenAI
+from core.data_models import PaperResult, PaperAnalysisResult
 from utils import config
 
-def get_structured_response(client: OpenAI, model: str, messages: list) -> dict:
+def initialize_session_state():
+    defaults = {
+        "search_mode": "キーワード検索",
+        "first_user_input": "",
+        "papers": PaperResult(),
+        "user_input_analysis": None,
+        "paper_analysis": None,
+        "num_search_papers": 10,
+        "year_range": (2023, 2025),
+        "search_engine": "semantic scholar",
+        "selected_paper": [],
+        "prev_selected_nodes": [],
+        "chat_history": [{"role": "system", "content": config.system_prompt}],
+        "initial_prompt_processed": True,
+    }
+
+    for key, value in defaults.items():
+        if key not in st.session_state:
+            st.session_state[key] = value
+
+def reset_chat_history():
+    st.session_state["chat_history"] = [{"role": "system", "content": config.system_prompt}]
+    st.session_state["initial_prompt_processed"] = False
+
+def update_selected_paper(selected_paper):
+    st.session_state["selected_paper"] = selected_paper
+    #st.session_state["initial_prompt_processed"] = False
+
+def update_paper_results(papers: PaperResult):
+    st.session_state["papers"] = papers
+
+def update_user_input_analysis(analysis: PaperAnalysisResult):
     """
-    lm studio jsonスキーマ固定出力
-    指定したモデルとメッセージでチャット補完を実行し、
-    返ってきたJSON形式のレスポンスを辞書型に変換して返す関数。
-    
-    Parameters:
-        client (OpenAI): OpenAIクライアントインスタンス
-        model (str): 使用するモデル名
-        messages (list): チャットで送信するメッセージのリスト
-    
-    Returns:
-        dict: 整形されたレスポンス（例: fields, labels など）
-    
-    Raises:
-        ValueError: JSONのパースに失敗した場合
+    analysis情報を
+    user_input_analysis
+    に保存
     """
-    response = client.chat.completions.create(
-        model=model,
-        messages=messages,
-        # 必要に応じて追加パラメータを設定
-    )
-    
+    st.session_state["user_input_analysis"] = analysis
 
-    # message.content全体を取得
-    result = response.choices[0].message.content
-    clean_lines = [line for line in result.splitlines() if not line.strip().startswith("```")]
-    result = "\n".join(clean_lines)
-    #print(result)
-
-
-    try:
-        structured_data = json.loads(result)
-    except json.JSONDecodeError as e:
-        print(result)
-        raise ValueError("レスポンスのJSON形式に誤りがあります") from e
-
-    return structured_data
-
-def stream_chat_response(messages, temperature=0.2):
+def update_user_results(analysis: PaperAnalysisResult):
     """
-    APIを呼び出してストリーミング応答を生成するジェネレーター関数
+    analysis情報を
+    paper_analysis
+    に保存
     """
-    # システムプロンプトやAPI設定
-    system_prompt = "あなたは誠実で優秀な日本人のアシスタントです。特に指示が無い場合は、常に日本語で回答してください。"
-    url1 = "http://192.168.11.26:1234/v1"
-    client = OpenAI(base_url=url1, api_key="lm-studio")
-    MODEL = "my-model"
-    stream = client.chat.completions.create(
-        model=MODEL,
-        messages=messages,
-        stream=True,
-        #temperature=temperature
-    )
-    response_text = ""
-    for chunk in stream:
-        delta = chunk.choices[0].delta
-        if delta.content:
-            response_text += delta.content
-            yield response_text
+    st.session_state["paper_analysis"] = analysis
 
-
-# 使用例
-if __name__ == "__main__":
-    client = OpenAI(base_url="http://192.168.11.26:1234/v1", api_key="lm-studio")
-    #client = OpenAI(base_url="http://localhost:11435/v1", api_key="gemma3:12b")
-    
-    #MODEL = "gemma3:12b"
-    MODEL = "my-model"
-    #MODEL = "gemma-3-12b-it@q3_k_l"
-    user_paper = '''"""感度解析を介した時系列遺伝子発現データ補完法の開発と創薬応用,承認薬を含む生物活性化合物は治療標的となるタンパク質に作用することで疾患治療のための作用を示す。しか し、それ以外のタンパク質に作用することで副作用のような期待していない作用を示す場合がある。したがって、 化合物の作用メカニズムを明らかにすることは、創薬における重要課題になっている。近年、オミクス情報に基づく、化合物の作用メカニズム予測が注目されている。例えば、化合物をヒト由来細胞に 添加して、一定時間後に遺伝子発現を観測した、化合物応答遺伝子発現データは、化合物の作用メカニズムの予測 に用いられている。しかしながら、このような遺伝子発現データは、コストや時間の制約により、特定の時間点で のみ観測され時系列で観測されていない。これによって、特定の時間点での解析を行うことはできるが、経時的に 解析を行うことができない。したがって、現状のデータから、化合物の経時的な影響を予測することは限界がある。そこで本研究では、細胞内システムに対して構築された数理モデルの感度解析を行い、得られた結果に基づき、 観測されている化合物応答遺伝子発現データから、時系列の遺伝子発現データを補完する新たな手法を開発することを目指した。"""'''
-    user_paper = '''"""多次元センサデータ処理のためのTransformerを用いた自己教師あり学習手法,センサ信号を入力として,人間行動認識を行う深層学習アルゴリズムを開発した. ここでは自然言語で用いられるTransformerに基づいた事前学習言語モデルを構築して, その事前学習言語モデルを用いて,下流タスクである人間行動認識タスクを解く形を追求する. VanillaのTransformerでもこれは可能であるが, ここでは, 線形層によるn次元数値データの埋め込み、ビン化処理、出力層の線形処理層という３つの要素を特色とするｎ次元数値処理トランスフォーマーを提案する。5種類のデータセットに対して、このモデルの効果を確かめた. VanillaのTransformerと比較して, 精度で10%～15%程度, 向上させることができた"""'''
-    #user_paper = '''"""P2LHAP: Wearable-Sensor-Based Human Activity Recognition, Segmentation, and Forecast Through Patch-to-Label Seq2Seq Transformer Traditional deep learning methods struggle to simultaneously segment, recognize, and forecast human activities from sensor data. This limits their usefulness in many fields, such as healthcare and assisted living, where real-time understanding of ongoing and upcoming activities is crucial. This article introduces P2LHAP, a novel Patch-to-Label Seq2Seq framework that tackles all three tasks in an efficient single-task model. P2LHAP divides sensor data streams into a sequence of “patches,” served as input tokens, and outputs a sequence of patch-level activity labels, including the predicted future activities. A unique smoothing technique based on surrounding patch labels, is proposed to identify activity boundaries accurately. Additionally, P2LHAP learns patch-level representation by sensor signal channel-independent Transformer encoders and decoders. All channels share embedding and Transformer weights across all sequences. Evaluated on the three public datasets, P2LHAP significantly outperforms the state-of-the-art in all three tasks, demonstrating its effectiveness and potential for real-world applications."""'''
-    messages = [
-        {
-            "role": "user",
-            "content": config.experiment_message_without_paper + user_paper
-        }
-    ]
-    
-    data = get_structured_response(client, MODEL, messages)
-    print(data)
-    print(data.keys())
-    #for item in data['fields']:
-    #    print(f"{item['name']}:{item['score']}")
+def update_search_settings(num_search_papers: int, year_range: tuple, search_engine: str):
+    st.session_state["num_search_papers"] = num_search_papers
+    st.session_state["year_range"] = year_range
+    st.session_state["search_engine"] = search_engine
 
 ```
 
-### File: streamlit_app/api/ollama_api.py
+### File: streamlit_app/state/state_manager_back.py
 
 ```python
-import requests
-import json
-from utils import config
-from jsonschema import validate, ValidationError
-
-def get_structured_response(model_name: str, prompt: str, temperature: float = 0.8, max_tokens: int = 500) -> dict:
-    """
-    Ollama の /api/generate エンドポイントを使い、指定したプロンプトで生成を実行します。
-    非ストリーミングのため、レスポンス全体を一度に取得して辞書型に変換します。
-    """
-    url_generate = config.OLLAMA_GENERATE_URL
-    data = {
-        "model": model_name,
-        "prompt": prompt,
-        "stream": False,
-        "temperature": temperature,
-        #"max_tokens": max_tokens
-    }
-    response = requests.post(url_generate, json=data)
-    if response.status_code != 200:
-        raise Exception(f"Error: {response.status_code}")
-    
-    result = response.text
-    # 不要なマークダウン（例: ```）が含まれている場合は除去
-    clean_lines = [line for line in result.splitlines() if not line.strip().startswith("```")]
-    clean_result = "\n".join(clean_lines)
-    
-    try:
-        structured_data = json.loads(clean_result)
-    except json.JSONDecodeError as e:
-        raise ValueError("レスポンスのJSON形式に誤りがあります.1") from e
-    
-    # 不要なマークダウン（例: ```）が含まれている場合は除去
-    clean_lines = [line for line in structured_data["response"].splitlines() if not line.strip().startswith("```")]
-    clean_result = "\n".join(clean_lines)
-
-    try:
-        structured_data = json.loads(clean_result)
-    except json.JSONDecodeError as e:
-        print(clean_result)
-        raise ValueError("レスポンスのJSON形式に誤りがあります.2") from e
-
-    return structured_data
-
-def get_structured_response_v2(model_name: str, prompt: str, temperature: float = 0.8, max_tokens: int = 500, json_schema: dict = config.structured_json_schema) -> dict:
-    """
-    Structured output機能を利用して、JSONスキーマに沿ったレスポンスを取得する改良版関数です。
-    
-    Parameters:
-        model_name (str): 使用するモデル名
-        prompt (str): ユーザーのプロンプト
-        temperature (float): 出力の多様性を制御するパラメータ
-        max_tokens (int): 最大トークン数（必要に応じて利用）
-        json_schema (dict): JSONスキーマを指定する場合に渡す。例:
-            {
-              "type": "object",
-              "properties": {
-                "name": { "type": "string" },
-                "capital": { "type": "string" },
-                "languages": {
-                  "type": "array",
-                  "items": { "type": "string" }
-                }
-              },
-              "required": ["name", "capital", "languages"]
-            }
-    
-    Returns:
-        dict: 解析済みの構造化されたレスポンス
-    """
-    url_chat = config.OLLAMA_CHAT_URL  # エンドポイントをchatに変更
-    payload = {
-        "model": model_name,
-        "messages": [{"role": "user", "content": prompt}],
-        "stream": False,
-        "temperature": temperature,
-    }
-    if json_schema:
-        payload["format"] = json_schema
-
-    response = requests.post(url_chat, json=payload)
-    if response.status_code != 200:
-        raise Exception(f"Error: {response.status_code}")
-    
-    result = response.text
-    
-    
-    try:
-        structured_data = json.loads(result)
-        print("\n\n",structured_data)
-    except json.JSONDecodeError as e:
-        raise ValueError("レスポンスのJSON形式に誤りがあります") from e
-    
-    try:
-        content = structured_data["message"]["content"]
-    except (KeyError, TypeError):
-        raise ValueError("レスポンス形式が想定と異なります")
-    
-    clean_lines = [line for line in content.splitlines() if not line.strip().startswith("```")]
-    clean_result = "\n".join(clean_lines)
-    
-    try:
-        structured_data = json.loads(clean_result)
-        print("\n\n", structured_data)
-    except json.JSONDecodeError as e:
-        print("abc")
-        print(clean_result)
-        print("def")
-        raise ValueError("レスポンスのJSON形式に誤りがあります.2") from e
-
-    # ここで、json_schema が指定されている場合はバリデーションを実施
-    if json_schema:
-        try:
-            validate(instance=structured_data, schema=json_schema)
-        except ValidationError as ve:
-            raise ValueError("レスポンスが指定されたJSONスキーマに準拠していません。") from ve
-
-    print("last data:\n\n\n\n", structured_data)
-    return structured_data
-
-def stream_chat_response(model_name: str, messages: list, temperature: float = 0.8):
-    """
-    Ollama の /api/chat エンドポイントを使い、ストリーミングでチャット応答を生成するジェネレーター関数です。
-    
-    Parameters:
-        model (str): 使用するモデル名（例: "llama2"）
-        messages (list): 各メッセージに "role" と "content" を含む辞書のリスト
-        temperature (float): 応答の多様性を制御するパラメータ
-    
-    Yields:
-        response_text (str): 累積された応答テキスト（逐次更新）
-    """
-    url_chat = config.OLLAMA_CHAT_URL
-    data = {
-        "model": model_name,
-        "messages": messages,
-        "stream": True,
-        "temperature": temperature
-    }
-    response = requests.post(url_chat, json=data, stream=True)
-    if response.status_code != 200:
-        print(f"Error: {response.status_code}")
-        return
-    
-    response_text = ""
-    """for chunk in response.iter_lines():
-        if chunk:
-            # 受信したチャンクは JSON ではなくプレーンなテキストとして返ってくる前提
-            text = chunk.decode("utf-8")
-            print(text, end="", flush=True)  # 改行せずにリアルタイム出力
-            response_text += text
-            yield response_text"""
-
-    for line in response.iter_lines():
-        if line:
-            try:
-                # 各チャンクは JSON 形式で送られてくると想定
-                chunk = json.loads(line.decode("utf-8"))
-                # 実際のレスポンス構造に合わせてキーを変更してください
-                # ここでは例として、"message" キーの中の "content" を取り出しています
-                content = ""
-                if "message" in chunk and "content" in chunk["message"]:
-                    content = chunk["message"]["content"]
-                else:
-                    # 例外対応: "text" キーの場合
-                    content = chunk.get("text", "")
-                if content:
-                    print(content, end="", flush=True)
-                    response_text += content
-                    yield response_text
-            except json.JSONDecodeError:
-                # JSONパースに失敗した場合、デコード済みの文字列をそのまま出力
-                decoded_line = line.decode("utf-8")
-                print(decoded_line, end="", flush=True)
-                response_text += decoded_line
-                yield response_text
-
-if __name__ == "__main__":
-    # 非ストリーミング生成の例
-    model = config.OLLAMA_MODEL
-    prompt = "自己紹介をお願いします"
-    try:
-        structured_response = get_structured_response(model, prompt)
-        print("Structured response:")
-        print(structured_response)
-    except Exception as e:
-        print("Error:", e)
-    
-    """# ストリーミングチャットの例
-    messages = [
-        { "role": "system", "content": "あなたは親切なアシスタントです" },
-        { "role": "user", "content": "こんにちは" },
-        { "role": "assistant", "content": "はい、何かお手伝いできることはありますか？" },
-        { "role": "user", "content": "天気について教えてください" }
-    ]
-    print("\nStreaming chat response:")
-    for full_response in stream_chat_response(model, messages):
-        # リアルタイムにコンソールへ出力されるので、ここでの処理は不要
-        pass
-"""
-```
-
-### File: streamlit_app/api/paper_api.py
-
-```python
-import requests
+# state_manager.py
 import streamlit as st
-import time
+#from utils.paper_controller import PaperResult
+from core.data_models import PaperResult
+from utils.llm_controller import PaperAnalysisResult
+from utils import config
 
-def search_papers_semantic(query: str, year_from: int = 2023,year_to: int = None, limit: int = 20, max_retries=10) -> list[dict]:
-    """
-    指定されたクエリでSemantic Scholar APIから論文情報を取得し、辞書のリストを返す関数。
-
-    Args:
-        query (str): 検索クエリ
-        year_from (int): 取得する論文の開始年（例: 2023）
-        limit (int): 取得件数の上限（最大1000件）
-
-    Returns:
-        list[dict]: 論文情報の辞書のリスト
-    """
-    url = "http://api.semanticscholar.org/graph/v1/paper/search/"
-    query_params = {
-        "query": query,
-        "fields": "title,abstract,url,publicationTypes",
-        #"year": f"{year_from}-",
-        "limit": limit,
-        "sort": "relevance",
-    }
-    if year_to is not None:
-        query_params["year"] = f"{year_from}-{year_to}"
-    else:
-        query_params["year"] = f"{year_from}-"
-
-    retries = 0
-    while retries < max_retries:
-        response = requests.get(url, params=query_params)
-        data = response.json()
-
-        if "data" in data:
-            #st.write(data)
-            return data["data"]
-        elif data.get("code") == "429":
-            st.warning("APIが混雑しています。自動で再試行します...")
-            time.sleep(1)
-            retries += 1
-            continue
-        else:
-            st.error("APIエラーが発生しました。再度検索ボタンを押してください。")
-            st.write(data)
-            return []
+def initialize_session_state():
+    # 検索モードと入力値
+    if "search_mode" not in st.session_state:
+        st.session_state["search_mode"] = "キーワード検索"
+    if "first_user_input" not in st.session_state:
+        st.session_state["first_user_input"] = ""
     
-    st.error("APIが混雑しています。時間をおいて再試行してください。")
-        
+    # 論文検索結果
+    if "papers" not in st.session_state:
+        st.session_state["papers"] = PaperResult()
+    
+    # ユーザー入力解析結果
+    if "user_input_analysis" not in st.session_state:
+        st.session_state["user_input_analysis"] = None
 
-# 使用例（この行は他ファイルで呼び出す場合の参考）
-# results = search_papers('"human activity recognition sensor transformer"')
-if __name__ == "__main__":
-    query = "Time-Series Gene Expression Data Imputation"
-    data = search_papers_semantic(query=query, year_from=2023, limit=20)
-    print(data)
-    print(len(data))
+    # 検索に関するオプション
+    if "num_search_papers" not in st.session_state:
+        st.session_state["num_search_papers"] = 10
+    if "year_range" not in st.session_state:
+        st.session_state["year_range"] = (2023, 2025)
+    if "search_engine" not in st.session_state:
+        st.session_state["search_engine"] = "semantic scholar"
+
+    # ネットワークで選択された論文
+    if "selected_paper" not in st.session_state:
+        st.session_state["selected_paper"] = []
+
+    # 論文表示のための1つ前の論文保存用
+    if "prev_selected_nodes" not in st.session_state:
+        st.session_state["prev_selected_nodes"] = []
+
+    if "chat_history" not in st.session_state:
+        st.session_state["chat_history"] = [{"role": "system", "content": config.system_prompt}]
+        st.session_state["initial_prompt_processed"] = True
+```
+
+### File: react_app/frontend/Dockerfile
+
+```
+FROM node:18
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . /app
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]
+
+```
+
+### File: react_app/frontend/src/main.tsx
+
+```
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+const App = () => <div>Paper Search Frontend</div>;
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+
+```
+
+### File: react_app/backend/Dockerfile
+
+```
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . /app
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+```
+
+### File: react_app/backend/main.py
+
+```python
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get("/health")
+async def health_check():
+    """ヘルスチェック用エンドポイント"""
+    return {"status": "ok"}
+
+
+```
+
+### File: react_app/backend/requirements.txt
+
+```
+fastapi
+uvicorn
+
 ```
 

--- a/project_export.md
+++ b/project_export.md
@@ -1,7 +1,5 @@
-## プロジェクト構成
-
-```
-paper_search/
+Markdown export complete: project_export.md
+h/
 ├── AGENTS.md
 ├── docker-compose.yml
 ├── react_app
@@ -148,6 +146,80 @@ services:
     container_name: react_frontend
     depends_on:
       - backend
+
+```
+
+### File: react_app/backend/Dockerfile
+
+```
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . /app
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+```
+
+### File: react_app/backend/main.py
+
+```python
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get("/health")
+async def health_check():
+    """ヘルスチェック用エンドポイント"""
+    return {"status": "ok"}
+
+
+```
+
+### File: react_app/backend/requirements.txt
+
+```
+fastapi
+uvicorn
+
+```
+
+### File: react_app/frontend/Dockerfile
+
+```
+FROM node:18
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . /app
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]
+
+```
+
+### File: react_app/frontend/src/main.tsx
+
+```
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+const App = () => <div>Paper Search Frontend</div>;
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
 
 ```
 
@@ -381,356 +453,6 @@ python-dotenv
 
 ```
 
-### File: streamlit_app/ui/__init__.py
-
-```python
-
-```
-
-### File: streamlit_app/ui/chat_panel.py
-
-```python
-# テキストチャット
-import streamlit as st
-from utils import llm_controller, config
-from api import lm_studio_api, ollama_api
-
-def render_history(chat_history, css_text_user, css_text_assistant):
-    """
-    チャット履歴をHTML形式でレンダリングする。
-    """
-    out = ""
-    script = """<script>
-        var chatBoxes = document.getElementsByClassName("chat-box");
-        if (chatBoxes.length > 0) {
-            chatBoxes[chatBoxes.length - 1].scrollTop = chatBoxes[chatBoxes.length - 1].scrollHeight;
-        }
-    </script>"""
-    for msg in chat_history:
-        if msg["role"] == "assistant":
-            out += f"""{css_text_assistant}<strong>Assistant:</strong> {msg['content']}</div>{script}\n\n"""
-        elif msg["role"] == "user":
-            out += f"""{css_text_user}<strong>User:</strong> {msg['content']}</div>{script}\n\n"""
-    return out
-
-def update_chat_history_with_response(api_messages, stream_placeholder):
-    """
-    LLM APIからのストリーミングレスポンスを処理し、チャット履歴を更新する。
-    """
-    #MODEL = config.OLLAMA_MODEL
-    MODEL = "gemma3:12b"
-    #MODEL = "deepseek-r1:8b-0528-qwen3-q8_0"
-    assistant_response = ""
-    #stream_placeholder = st.empty()  # ストリーミング更新用プレースホルダー
-    for updated_text in ollama_api.stream_chat_response(model_name=MODEL,messages=api_messages):
-        assistant_response = updated_text
-        stream_placeholder.markdown(f"<strong>Assistant:</strong> {updated_text}</div>", unsafe_allow_html=True)
-    stream_placeholder.empty()
-    st.session_state["chat_history"].append({
-        "role": "assistant",
-        "content": assistant_response
-    })
-    return assistant_response
-
-def render_stream(stream_placeholder, selected_paper):
-    selected_paper_content = f"{selected_paper['title']}, {selected_paper['abstract']}"
-    if st.session_state["search_mode"] == "AI検索 2":
-        initial_prompt = (
-            f"{config.INST_PROMPT_AI}\nユーザー論文:{st.session_state['first_user_input']}"
-            f"\"\"\"選択された論文\"\"\"{selected_paper_content}\"\"\""
-        )
-    elif st.session_state["search_mode"] == "キーワード検索":
-        initial_prompt = (
-            f"{config.INST_PROMPT_KEYWORDS}\n"
-            f"検索キーワード：{st.session_state['first_user_input']}\n論文：{selected_paper_content}"
-        )
-    else:
-        st.error("検索方法が指定されていないことになっています。")
-        return
-
-    st.session_state["chat_history"].append({
-        "role": "hidden_user",
-        "content": initial_prompt
-    })
-
-    # hidden_user を user に変換した API 用メッセージリストの作成
-    api_messages = [
-        {"role": "user" if msg["role"] == "hidden_user" else msg["role"], "content": msg["content"]}
-        for msg in st.session_state["chat_history"]
-    ]
-    update_chat_history_with_response(api_messages, stream_placeholder)
-
-        
-```
-
-### File: streamlit_app/ui/paper_network.py
-
-```python
-# ui/paper_network_and_basic_info.py
-import streamlit as st
-from utils import cytoscape_utils
-from utils import field_colors
-from st_cytoscape import cytoscape
-
-def render_network_sections(papers, details=False):
-    analysis_map = {}
-    all_analyzed = True
-    for paper in papers.papers:
-        key = f"paper_analysis_{paper.paper_id}"
-        analysis = st.session_state.get(key)
-        if analysis:
-            analysis_map[paper.paper_id] = analysis
-        else:
-            all_analyzed = False
-
-    if all_analyzed and analysis_map:
-        elements = cytoscape_utils.build_cy_elements_by_field(papers, analysis_map)
-    else:
-        elements = cytoscape_utils.build_cy_elements_simple(papers)
-    style_sheet = [
-        {
-            "selector": "node",
-            "style": {
-                "label": "data(label)",
-                "font-size": "10px",
-                "color": "#333",
-                "background-color": "data(color)",
-                "width": "35px",
-                "height": "35px",
-            },
-        },
-        {
-            "selector": "edge",
-            "style": {
-                "width": 2,
-                "line-color": "#ccc",
-                "target-arrow-shape": "triangle",
-                "target-arrow-color": "#ccc",
-                "curve-style": "bezier",
-            }
-        },
-        {
-            "selector": "node:selected",
-            "style": {
-                "background-color": "#FF0000",
-                "border-color": "#F00",
-                "border-width": "2px",
-            }
-        },
-        {
-            "selector": "[type='field']",
-            "style": {"shape": "rectangle", "width": "50px", "height": "50px"},
-        },
-        {
-            "selector": "[type='subfield']",
-            "style": {"shape": "round-rectangle", "width": "45px", "height": "45px"},
-        },
-        {
-            "selector": "[type='paper']",
-            "style": {"shape": "ellipse", "width": "35px", "height": "35px"},
-        },
-    ]
-    layout = {"name": "preset"}
-    
-    with st.container():
-        selected = cytoscape(
-            elements,
-            style_sheet,
-            height="800px",
-            layout=layout,
-            key="graph",
-            selection_type="single",
-            min_zoom=0.5,
-            max_zoom=1
-        )
-    # ノード情報の高速検索用辞書（センター以外）
-    element_dict = {str(f"{e['data']['id']}"): e for e in elements if e["data"]["id"] != "center"}
-    # 論文情報を paper_id でマッピング（ここでは PaperFields の paper_id と対応付け）
-    papers_dict = {str(f"paper_{p.paper_id}"): p for p in papers.papers}
-    
-    return selected, element_dict, papers_dict
-
-def get_selected_papers(selected, element_dict, papers_dict):
-    """
-    選択されたノードから論文情報のリストを作成する関数
-    """
-    selected_papers = []
-    if selected and "nodes" in selected:
-        for node_id in selected["nodes"]:
-            if node_id == "center":
-                continue
-            node_papers = papers_dict.get(node_id)
-            node_elem = element_dict.get(node_id)
-            if not node_papers:
-                print("why")
-                continue
-            selected_papers.append({
-                "title": node_papers.title,
-                "abstract": node_papers.abstract,
-                "url": node_papers.url,
-                "paper_id": node_papers.paper_id,
-                "relatedness": node_elem["data"]["relatedness"],
-            #    "relatedness": getattr(paper, "relatedness", 0),  # 存在しない場合は0とする例
-            #    "university": getattr(paper, "university", "不明"),
-            #    "url": paper.url,
-            #    "abstract": paper.abstract,
-            })
-    return selected_papers
-```
-
-### File: streamlit_app/ui/result_summary.py
-
-```python
-# ui/result_summary.py
-import streamlit as st
-import plotly.express as px
-import pandas as pd
-from utils.field_colors import get_field_color
-
-def render__paper_info_analysis(fields):
-    if not fields:
-        st.warning("データがありません。")
-        return
-
-    total_score = sum(field.score for field in fields)
-    data = [
-        {"name": field.name, "score": field.score, "percentage": 100 * field.score / total_score}
-        for field in fields
-    ]
-    df = pd.DataFrame(data).copy().sort_values("percentage", ascending=False)
-    sorted_names = df["name"].tolist()
-
-    color_map = {name: get_field_color(name) for name in df["name"]}
-
-    fig = px.pie(
-        df,
-        names="name",
-        values="percentage",
-        title="各分野の割合（多い順・時計回り）",
-        category_orders={"name": sorted_names},
-        color="name",
-        color_discrete_map=color_map,
-    )
-    fig.update_traces(direction="clockwise")
-    st.plotly_chart(fig, use_container_width=True)
-
-def render_paper_analysis_result(result):
-    data = {}
-    if result.title:
-        data["タイトル"] = result.title
-    if result.fields:
-        data["分野"] = ", ".join([f"{field.name} ({field.score})" for field in result.fields])
-    if result.target:
-        data["対象"] = result.target.ja
-    if result.methods:
-        data["手法"] = ", ".join([label.ja for label in result.methods])
-    if result.factors:
-        data["要因"] = ", ".join([label.ja for label in result.factors])
-    if result.metrics:
-        data["指標"] = ", ".join([label.ja for label in result.metrics])
-    if result.search_keywords:
-        data["検索キーワード"] = ", ".join([label.ja for label in result.search_keywords])
-    if result.main_keywords:
-        data["主要キーワード"] = ", ".join([label.ja for label in result.main_keywords])
-    
-    df = pd.DataFrame.from_dict(data, orient="index", columns=["内容"])
-    st.table(df)
-
-def render_info_paper(papers):
-    for paper in papers:
-        st.write(f"タイトル: {paper['title']}")
-        st.write(f"関連順位: {paper.get('relatedness', 0)} 位")
-        st.write(f"URL: {paper['url']}")
-        st.write(f"アブストラクト：\n {paper['abstract']}")
-        st.write("---")
-
-```
-
-### File: streamlit_app/ui/search_bar.py
-
-```python
-# ui/search_bar.py
-
-import streamlit as st
-from core import paper_service, llm_service
-from state import state_manager
-
-def render_search_section():
-    st.radio(
-        "検索モード選択:",
-        ("キーワード検索", "AI検索 1", "AI検索 2"),
-        horizontal=True,
-        key="search_mode"
-    )
-
-    st.caption(
-        '※ キーワード検索 : 指定されたキーワードで検索を行います。（例：「genarative ai transformer」）',
-        unsafe_allow_html=True
-    )
-    st.caption(
-        '※ AI検索 1 : 入力された文章から関連度の高い論文を自動で解析し検索します。（例：「～～に関する論文が知りたい」）',
-        unsafe_allow_html=True
-    )
-    st.caption(
-        '※ AI検索 2 : 論文で論文を検索する場合は「(論文タイトル),(論文アブストラクト)」の形式にしてください。',
-        unsafe_allow_html=True
-    )
-
-    input_col, search_button = st.columns([8, 2])
-
-    with input_col:
-        st.text_area("入力:", value="", placeholder="ここに入力...", key="first_user_input")
-
-    with search_button:
-        if st.button("検索実行"):
-            query = st.session_state["first_user_input"]
-            mode = st.session_state["search_mode"]
-            engine = st.session_state["search_engine"]
-            year_range = st.session_state["year_range"]
-            num_papers = st.session_state["num_search_papers"]
-
-            if mode == "キーワード検索":
-                results = paper_service.fetch_papers_by_query(query, year_range, num_papers)
-                state_manager.update_paper_results(results)
-
-            elif mode == "AI検索 2":
-                analysis = llm_service.analyze_user_paper(query)
-                state_manager.update_user_input_analysis(analysis)
-                ai_query = analysis.search_keywords[0].en
-                results = paper_service.fetch_papers_by_query(ai_query, year_range, num_papers)
-                state_manager.update_paper_results(results)
-
-def render_search_info_selection_section():
-    with st.expander("オプション設定"):
-        search_num_col, year_col, search_engine_col = st.columns([1, 1, 1])
-
-        with search_num_col:
-            st.slider(
-                "検索する論文数",
-                1,
-                50,
-                st.session_state["num_search_papers"],
-                key="num_search_papers",
-            )
-        with year_col:
-            st.slider(
-                "発行年の範囲",
-                1970,
-                2025,
-                st.session_state["year_range"],
-                key="year_range",
-            )
-        with search_engine_col:
-            st.radio(
-                "検索エンジン選択:",
-                ("semantic scholar", "Google Scholar"),
-                horizontal=True,
-                key="search_engine",
-            )
-
-
-```
-
 ### File: streamlit_app/state/__init__.py
 
 ```python
@@ -846,6 +568,135 @@ def initialize_session_state():
         st.session_state["initial_prompt_processed"] = True
 ```
 
+### File: streamlit_app/core/__init__.py
+
+```python
+
+```
+
+### File: streamlit_app/core/data_models.py
+
+```python
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+@dataclass
+class PaperField:
+    name: str
+    score: float
+
+@dataclass
+class Label:
+    ja: str
+    en: str
+
+@dataclass
+class PaperAnalysisResult:
+    fields: List[PaperField]
+    target: Label
+    title: Optional[str] = None
+    methods: Optional[List[Label]] = None
+    factors: Optional[List[Label]] = None
+    metrics: Optional[List[Label]] = None
+    search_keywords: Optional[List[Label]] = None
+    main_keywords: Optional[List[Label]] = None
+
+@dataclass
+class PaperInfo:
+    title: str
+    abstract: Optional[str]
+    url: str
+    paper_id: str
+    relatedness: Optional[int] = None
+
+@dataclass
+class PaperResult:
+    papers: List[PaperInfo] = field(default_factory=list)
+
+```
+
+### File: streamlit_app/core/llm_service.py
+
+```python
+# core/llm_service.py
+
+from core.data_models import PaperAnalysisResult, PaperField, Label
+from api import ollama_api, lm_studio_api
+from utils import config
+
+def analyze_user_paper(input_text: str, api_type: str = "ollama") -> PaperAnalysisResult:
+    prompt = config.experiment_message_without_paper + input_text
+    
+    if api_type == "ollama":
+        data = ollama_api.get_structured_response_v2(config.OLLAMA_MODEL, prompt)
+    elif api_type == "lm_studio":
+        client = lm_studio_api.OpenAI(base_url="http://192.168.11.26:1234/v1", api_key="lm_studio")
+        messages = [{"role": "user", "content": prompt}]
+        data = lm_studio_api.get_structured_response(client, "my-model", messages)
+    else:
+        raise ValueError("Unsupported API type provided.")
+
+    return PaperAnalysisResult(
+        fields=[PaperField(name=f["name"], score=f["score"]) for f in data["fields"]],
+        target=Label(**data["labels"]["target"]),
+        title=data.get("title"),
+        methods=[Label(**m) for m in data["labels"]["approaches"]["methods"]],
+        factors=[Label(**f) for f in data["labels"]["approaches"]["factors"]],
+        metrics=[Label(**m) for m in data["labels"]["approaches"]["metrics"]],
+        search_keywords=[Label(**kw) for kw in data["labels"]["search_keywords"]]
+    )
+
+def analyze_searched_paper(input_text: str, api_type: str = "ollama") -> PaperAnalysisResult:
+    prompt = config.experiment_message_without_paper + input_text
+    
+    if api_type == "ollama":
+        data = ollama_api.get_structured_response_v2(config.OLLAMA_MODEL, prompt)
+    elif api_type == "lm_studio":
+        client = lm_studio_api.OpenAI(base_url="http://192.168.11.26:1234/v1", api_key="lm_studio")
+        messages = [{"role": "user", "content": prompt}]
+        data = lm_studio_api.get_structured_response(client, "my-model", messages)
+    else:
+        raise ValueError("Unsupported API type provided.")
+
+    return PaperAnalysisResult(
+        fields=[PaperField(name=f["name"], score=f["score"]) for f in data["fields"]],
+        target=Label(**data["labels"]["target"]),
+        title=data.get("title"),
+        methods=[Label(**m) for m in data["labels"]["approaches"]["methods"]],
+        factors=[Label(**f) for f in data["labels"]["approaches"]["factors"]],
+        metrics=[Label(**m) for m in data["labels"]["approaches"]["metrics"]],
+        search_keywords=[Label(**kw) for kw in data["labels"]["search_keywords"]]
+    )
+
+```
+
+### File: streamlit_app/core/paper_service.py
+
+```python
+# 論文APIへのアクセスロジック
+# core/paper_service.py
+
+from core.data_models import PaperResult, PaperInfo
+from api.paper_api import search_papers_semantic
+from typing import Tuple
+
+def fetch_papers_by_query(query: str, year_range: Tuple[int, int], limit: int = 10) -> PaperResult:
+    year_from, year_to = year_range
+    raw_papers = search_papers_semantic(query, year_from=year_from, year_to=year_to, limit=limit)
+    
+    papers = [
+        PaperInfo(
+            title=paper["title"],
+            abstract=paper.get("abstract"),
+            url=paper["url"],
+            paper_id=paper["paperId"]
+        )
+        for paper in raw_papers
+    ]
+    return PaperResult(papers=papers)
+
+```
+
 ### File: streamlit_app/utils/__init__.py
 
 ```python
@@ -874,6 +725,13 @@ default_ollama_url = (
     "http://host.docker.internal:11435" if running_in_docker() else "http://127.0.0.1:11435"
 )
 OLLAMA_API_BASE_URL = os.environ.get("OLLAMA_API_BASE_URL", default_ollama_url)
+# API エンドポイントの組み立てを一元化
+def get_ollama_url(path: str) -> str:
+    """Ollama API 用の完全な URL を返す"""
+    return f"{OLLAMA_API_BASE_URL}{path}"
+
+OLLAMA_CHAT_URL = get_ollama_url("/api/chat")
+OLLAMA_GENERATE_URL = get_ollama_url("/api/generate")
 #OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "deepseek-r1:8b-0528-qwen3-q8_0")
 _experiment_message_template = '''
 以下は論文の情報です。
@@ -1694,132 +1552,353 @@ if __name__ == "__main__":
     print("abstract:", data.paper[0].abstract)
 ```
 
-### File: streamlit_app/core/__init__.py
+### File: streamlit_app/ui/__init__.py
 
 ```python
 
 ```
 
-### File: streamlit_app/core/data_models.py
+### File: streamlit_app/ui/chat_panel.py
 
 ```python
-from dataclasses import dataclass, field
-from typing import List, Optional
+# テキストチャット
+import streamlit as st
+from utils import llm_controller, config
+from api import lm_studio_api, ollama_api
 
-@dataclass
-class PaperField:
-    name: str
-    score: float
+def render_history(chat_history, css_text_user, css_text_assistant):
+    """
+    チャット履歴をHTML形式でレンダリングする。
+    """
+    out = ""
+    script = """<script>
+        var chatBoxes = document.getElementsByClassName("chat-box");
+        if (chatBoxes.length > 0) {
+            chatBoxes[chatBoxes.length - 1].scrollTop = chatBoxes[chatBoxes.length - 1].scrollHeight;
+        }
+    </script>"""
+    for msg in chat_history:
+        if msg["role"] == "assistant":
+            out += f"""{css_text_assistant}<strong>Assistant:</strong> {msg['content']}</div>{script}\n\n"""
+        elif msg["role"] == "user":
+            out += f"""{css_text_user}<strong>User:</strong> {msg['content']}</div>{script}\n\n"""
+    return out
 
-@dataclass
-class Label:
-    ja: str
-    en: str
+def update_chat_history_with_response(api_messages, stream_placeholder):
+    """
+    LLM APIからのストリーミングレスポンスを処理し、チャット履歴を更新する。
+    """
+    #MODEL = config.OLLAMA_MODEL
+    MODEL = "gemma3:12b"
+    #MODEL = "deepseek-r1:8b-0528-qwen3-q8_0"
+    assistant_response = ""
+    #stream_placeholder = st.empty()  # ストリーミング更新用プレースホルダー
+    for updated_text in ollama_api.stream_chat_response(model_name=MODEL,messages=api_messages):
+        assistant_response = updated_text
+        stream_placeholder.markdown(f"<strong>Assistant:</strong> {updated_text}</div>", unsafe_allow_html=True)
+    stream_placeholder.empty()
+    st.session_state["chat_history"].append({
+        "role": "assistant",
+        "content": assistant_response
+    })
+    return assistant_response
 
-@dataclass
-class PaperAnalysisResult:
-    fields: List[PaperField]
-    target: Label
-    title: Optional[str] = None
-    methods: Optional[List[Label]] = None
-    factors: Optional[List[Label]] = None
-    metrics: Optional[List[Label]] = None
-    search_keywords: Optional[List[Label]] = None
-    main_keywords: Optional[List[Label]] = None
-
-@dataclass
-class PaperInfo:
-    title: str
-    abstract: Optional[str]
-    url: str
-    paper_id: str
-    relatedness: Optional[int] = None
-
-@dataclass
-class PaperResult:
-    papers: List[PaperInfo] = field(default_factory=list)
-
-```
-
-### File: streamlit_app/core/llm_service.py
-
-```python
-# core/llm_service.py
-
-from core.data_models import PaperAnalysisResult, PaperField, Label
-from api import ollama_api, lm_studio_api
-from utils import config
-
-def analyze_user_paper(input_text: str, api_type: str = "ollama") -> PaperAnalysisResult:
-    prompt = config.experiment_message_without_paper + input_text
-    
-    if api_type == "ollama":
-        data = ollama_api.get_structured_response_v2(config.OLLAMA_MODEL, prompt)
-    elif api_type == "lm_studio":
-        client = lm_studio_api.OpenAI(base_url="http://192.168.11.26:1234/v1", api_key="lm_studio")
-        messages = [{"role": "user", "content": prompt}]
-        data = lm_studio_api.get_structured_response(client, "my-model", messages)
-    else:
-        raise ValueError("Unsupported API type provided.")
-
-    return PaperAnalysisResult(
-        fields=[PaperField(name=f["name"], score=f["score"]) for f in data["fields"]],
-        target=Label(**data["labels"]["target"]),
-        title=data.get("title"),
-        methods=[Label(**m) for m in data["labels"]["approaches"]["methods"]],
-        factors=[Label(**f) for f in data["labels"]["approaches"]["factors"]],
-        metrics=[Label(**m) for m in data["labels"]["approaches"]["metrics"]],
-        search_keywords=[Label(**kw) for kw in data["labels"]["search_keywords"]]
-    )
-
-def analyze_searched_paper(input_text: str, api_type: str = "ollama") -> PaperAnalysisResult:
-    prompt = config.experiment_message_without_paper + input_text
-    
-    if api_type == "ollama":
-        data = ollama_api.get_structured_response_v2(config.OLLAMA_MODEL, prompt)
-    elif api_type == "lm_studio":
-        client = lm_studio_api.OpenAI(base_url="http://192.168.11.26:1234/v1", api_key="lm_studio")
-        messages = [{"role": "user", "content": prompt}]
-        data = lm_studio_api.get_structured_response(client, "my-model", messages)
-    else:
-        raise ValueError("Unsupported API type provided.")
-
-    return PaperAnalysisResult(
-        fields=[PaperField(name=f["name"], score=f["score"]) for f in data["fields"]],
-        target=Label(**data["labels"]["target"]),
-        title=data.get("title"),
-        methods=[Label(**m) for m in data["labels"]["approaches"]["methods"]],
-        factors=[Label(**f) for f in data["labels"]["approaches"]["factors"]],
-        metrics=[Label(**m) for m in data["labels"]["approaches"]["metrics"]],
-        search_keywords=[Label(**kw) for kw in data["labels"]["search_keywords"]]
-    )
-
-```
-
-### File: streamlit_app/core/paper_service.py
-
-```python
-# 論文APIへのアクセスロジック
-# core/paper_service.py
-
-from core.data_models import PaperResult, PaperInfo
-from api.paper_api import search_papers_semantic
-from typing import Tuple
-
-def fetch_papers_by_query(query: str, year_range: Tuple[int, int], limit: int = 10) -> PaperResult:
-    year_from, year_to = year_range
-    raw_papers = search_papers_semantic(query, year_from=year_from, year_to=year_to, limit=limit)
-    
-    papers = [
-        PaperInfo(
-            title=paper["title"],
-            abstract=paper.get("abstract"),
-            url=paper["url"],
-            paper_id=paper["paperId"]
+def render_stream(stream_placeholder, selected_paper):
+    selected_paper_content = f"{selected_paper['title']}, {selected_paper['abstract']}"
+    if st.session_state["search_mode"] == "AI検索 2":
+        initial_prompt = (
+            f"{config.INST_PROMPT_AI}\nユーザー論文:{st.session_state['first_user_input']}"
+            f"\"\"\"選択された論文\"\"\"{selected_paper_content}\"\"\""
         )
-        for paper in raw_papers
+    elif st.session_state["search_mode"] == "キーワード検索":
+        initial_prompt = (
+            f"{config.INST_PROMPT_KEYWORDS}\n"
+            f"検索キーワード：{st.session_state['first_user_input']}\n論文：{selected_paper_content}"
+        )
+    else:
+        st.error("検索方法が指定されていないことになっています。")
+        return
+
+    st.session_state["chat_history"].append({
+        "role": "hidden_user",
+        "content": initial_prompt
+    })
+
+    # hidden_user を user に変換した API 用メッセージリストの作成
+    api_messages = [
+        {"role": "user" if msg["role"] == "hidden_user" else msg["role"], "content": msg["content"]}
+        for msg in st.session_state["chat_history"]
     ]
-    return PaperResult(papers=papers)
+    update_chat_history_with_response(api_messages, stream_placeholder)
+
+        
+```
+
+### File: streamlit_app/ui/paper_network.py
+
+```python
+# ui/paper_network_and_basic_info.py
+import streamlit as st
+from utils import cytoscape_utils
+from utils import field_colors
+from st_cytoscape import cytoscape
+
+def render_network_sections(papers, details=False):
+    analysis_map = {}
+    all_analyzed = True
+    for paper in papers.papers:
+        key = f"paper_analysis_{paper.paper_id}"
+        analysis = st.session_state.get(key)
+        if analysis:
+            analysis_map[paper.paper_id] = analysis
+        else:
+            all_analyzed = False
+
+    if all_analyzed and analysis_map:
+        elements = cytoscape_utils.build_cy_elements_by_field(papers, analysis_map)
+    else:
+        elements = cytoscape_utils.build_cy_elements_simple(papers)
+    style_sheet = [
+        {
+            "selector": "node",
+            "style": {
+                "label": "data(label)",
+                "font-size": "10px",
+                "color": "#333",
+                "background-color": "data(color)",
+                "width": "35px",
+                "height": "35px",
+            },
+        },
+        {
+            "selector": "edge",
+            "style": {
+                "width": 2,
+                "line-color": "#ccc",
+                "target-arrow-shape": "triangle",
+                "target-arrow-color": "#ccc",
+                "curve-style": "bezier",
+            }
+        },
+        {
+            "selector": "node:selected",
+            "style": {
+                "background-color": "#FF0000",
+                "border-color": "#F00",
+                "border-width": "2px",
+            }
+        },
+        {
+            "selector": "[type='field']",
+            "style": {"shape": "rectangle", "width": "50px", "height": "50px"},
+        },
+        {
+            "selector": "[type='subfield']",
+            "style": {"shape": "round-rectangle", "width": "45px", "height": "45px"},
+        },
+        {
+            "selector": "[type='paper']",
+            "style": {"shape": "ellipse", "width": "35px", "height": "35px"},
+        },
+    ]
+    layout = {"name": "preset"}
+    
+    with st.container():
+        selected = cytoscape(
+            elements,
+            style_sheet,
+            height="800px",
+            layout=layout,
+            key="graph",
+            selection_type="single",
+            min_zoom=0.5,
+            max_zoom=1
+        )
+    # ノード情報の高速検索用辞書（センター以外）
+    element_dict = {str(f"{e['data']['id']}"): e for e in elements if e["data"]["id"] != "center"}
+    # 論文情報を paper_id でマッピング（ここでは PaperFields の paper_id と対応付け）
+    papers_dict = {str(f"paper_{p.paper_id}"): p for p in papers.papers}
+    
+    return selected, element_dict, papers_dict
+
+def get_selected_papers(selected, element_dict, papers_dict):
+    """
+    選択されたノードから論文情報のリストを作成する関数
+    """
+    selected_papers = []
+    if selected and "nodes" in selected:
+        for node_id in selected["nodes"]:
+            if node_id == "center":
+                continue
+            node_papers = papers_dict.get(node_id)
+            node_elem = element_dict.get(node_id)
+            if not node_papers:
+                print("why")
+                continue
+            selected_papers.append({
+                "title": node_papers.title,
+                "abstract": node_papers.abstract,
+                "url": node_papers.url,
+                "paper_id": node_papers.paper_id,
+                "relatedness": node_elem["data"]["relatedness"],
+            #    "relatedness": getattr(paper, "relatedness", 0),  # 存在しない場合は0とする例
+            #    "university": getattr(paper, "university", "不明"),
+            #    "url": paper.url,
+            #    "abstract": paper.abstract,
+            })
+    return selected_papers
+```
+
+### File: streamlit_app/ui/result_summary.py
+
+```python
+# ui/result_summary.py
+import streamlit as st
+import plotly.express as px
+import pandas as pd
+from utils.field_colors import get_field_color
+
+def render__paper_info_analysis(fields):
+    if not fields:
+        st.warning("データがありません。")
+        return
+
+    total_score = sum(field.score for field in fields)
+    data = [
+        {"name": field.name, "score": field.score, "percentage": 100 * field.score / total_score}
+        for field in fields
+    ]
+    df = pd.DataFrame(data).copy().sort_values("percentage", ascending=False)
+    sorted_names = df["name"].tolist()
+
+    color_map = {name: get_field_color(name) for name in df["name"]}
+
+    fig = px.pie(
+        df,
+        names="name",
+        values="percentage",
+        title="各分野の割合（多い順・時計回り）",
+        category_orders={"name": sorted_names},
+        color="name",
+        color_discrete_map=color_map,
+    )
+    fig.update_traces(direction="clockwise")
+    st.plotly_chart(fig, use_container_width=True)
+
+def render_paper_analysis_result(result):
+    data = {}
+    if result.title:
+        data["タイトル"] = result.title
+    if result.fields:
+        data["分野"] = ", ".join([f"{field.name} ({field.score})" for field in result.fields])
+    if result.target:
+        data["対象"] = result.target.ja
+    if result.methods:
+        data["手法"] = ", ".join([label.ja for label in result.methods])
+    if result.factors:
+        data["要因"] = ", ".join([label.ja for label in result.factors])
+    if result.metrics:
+        data["指標"] = ", ".join([label.ja for label in result.metrics])
+    if result.search_keywords:
+        data["検索キーワード"] = ", ".join([label.ja for label in result.search_keywords])
+    if result.main_keywords:
+        data["主要キーワード"] = ", ".join([label.ja for label in result.main_keywords])
+    
+    df = pd.DataFrame.from_dict(data, orient="index", columns=["内容"])
+    st.table(df)
+
+def render_info_paper(papers):
+    for paper in papers:
+        st.write(f"タイトル: {paper['title']}")
+        st.write(f"関連順位: {paper.get('relatedness', 0)} 位")
+        st.write(f"URL: {paper['url']}")
+        st.write(f"アブストラクト：\n {paper['abstract']}")
+        st.write("---")
+
+```
+
+### File: streamlit_app/ui/search_bar.py
+
+```python
+# ui/search_bar.py
+
+import streamlit as st
+from core import paper_service, llm_service
+from state import state_manager
+
+def render_search_section():
+    st.radio(
+        "検索モード選択:",
+        ("キーワード検索", "AI検索 1", "AI検索 2"),
+        horizontal=True,
+        key="search_mode"
+    )
+
+    st.caption(
+        '※ キーワード検索 : 指定されたキーワードで検索を行います。（例：「genarative ai transformer」）',
+        unsafe_allow_html=True
+    )
+    st.caption(
+        '※ AI検索 1 : 入力された文章から関連度の高い論文を自動で解析し検索します。（例：「～～に関する論文が知りたい」）',
+        unsafe_allow_html=True
+    )
+    st.caption(
+        '※ AI検索 2 : 論文で論文を検索する場合は「(論文タイトル),(論文アブストラクト)」の形式にしてください。',
+        unsafe_allow_html=True
+    )
+
+    input_col, search_button = st.columns([8, 2])
+
+    with input_col:
+        st.text_area("入力:", value="", placeholder="ここに入力...", key="first_user_input")
+
+    with search_button:
+        if st.button("検索実行"):
+            query = st.session_state["first_user_input"]
+            mode = st.session_state["search_mode"]
+            engine = st.session_state["search_engine"]
+            year_range = st.session_state["year_range"]
+            num_papers = st.session_state["num_search_papers"]
+
+            if mode == "キーワード検索":
+                results = paper_service.fetch_papers_by_query(query, year_range, num_papers)
+                state_manager.update_paper_results(results)
+
+            elif mode == "AI検索 2":
+                analysis = llm_service.analyze_user_paper(query)
+                state_manager.update_user_input_analysis(analysis)
+                ai_query = analysis.search_keywords[0].en
+                results = paper_service.fetch_papers_by_query(ai_query, year_range, num_papers)
+                state_manager.update_paper_results(results)
+
+def render_search_info_selection_section():
+    with st.expander("オプション設定"):
+        search_num_col, year_col, search_engine_col = st.columns([1, 1, 1])
+
+        with search_num_col:
+            st.slider(
+                "検索する論文数",
+                1,
+                50,
+                st.session_state["num_search_papers"],
+                key="num_search_papers",
+            )
+        with year_col:
+            st.slider(
+                "発行年の範囲",
+                1970,
+                2025,
+                st.session_state["year_range"],
+                key="year_range",
+            )
+        with search_engine_col:
+            st.radio(
+                "検索エンジン選択:",
+                ("semantic scholar", "Google Scholar"),
+                horizontal=True,
+                key="search_engine",
+            )
+
 
 ```
 
@@ -1937,7 +2016,7 @@ def get_structured_response(model_name: str, prompt: str, temperature: float = 0
     Ollama の /api/generate エンドポイントを使い、指定したプロンプトで生成を実行します。
     非ストリーミングのため、レスポンス全体を一度に取得して辞書型に変換します。
     """
-    url_generate = f"{config.OLLAMA_API_BASE_URL}/api/generate"
+    url_generate = config.OLLAMA_GENERATE_URL
     data = {
         "model": model_name,
         "prompt": prompt,
@@ -1997,7 +2076,7 @@ def get_structured_response_v2(model_name: str, prompt: str, temperature: float 
     Returns:
         dict: 解析済みの構造化されたレスポンス
     """
-    url_chat = f"{config.OLLAMA_API_BASE_URL}/api/chat"  # エンドポイントをchatに変更
+    url_chat = config.OLLAMA_CHAT_URL  # エンドポイントをchatに変更
     payload = {
         "model": model_name,
         "messages": [{"role": "user", "content": prompt}],
@@ -2059,7 +2138,7 @@ def stream_chat_response(model_name: str, messages: list, temperature: float = 0
     Yields:
         response_text (str): 累積された応答テキスト（逐次更新）
     """
-    url_chat = f"{config.OLLAMA_API_BASE_URL}/api/chat"
+    url_chat = config.OLLAMA_CHAT_URL
     data = {
         "model": model_name,
         "messages": messages,
@@ -2189,79 +2268,5 @@ if __name__ == "__main__":
     data = search_papers_semantic(query=query, year_from=2023, limit=20)
     print(data)
     print(len(data))
-```
-
-### File: react_app/frontend/Dockerfile
-
-```
-FROM node:18
-WORKDIR /app
-COPY package.json ./
-RUN npm install
-COPY . /app
-EXPOSE 5173
-CMD ["npm", "run", "dev", "--", "--host"]
-
-```
-
-### File: react_app/frontend/src/main.tsx
-
-```
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-
-const App = () => <div>Paper Search Frontend</div>;
-
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
-
-```
-
-### File: react_app/backend/Dockerfile
-
-```
-FROM python:3.10-slim
-WORKDIR /app
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-COPY . /app
-EXPOSE 8000
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
-
-```
-
-### File: react_app/backend/main.py
-
-```python
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-
-app = FastAPI()
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-@app.get("/health")
-async def health_check():
-    """ヘルスチェック用エンドポイント"""
-    return {"status": "ok"}
-
-
-```
-
-### File: react_app/backend/requirements.txt
-
-```
-fastapi
-uvicorn
-
 ```
 

--- a/streamlit_app/Dockerfile
+++ b/streamlit_app/Dockerfile
@@ -2,7 +2,6 @@ FROM python:3.10-slim
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-ENV OLLAMA_API_BASE_URL=http://host.docker.internal:11435
 COPY . /app
 EXPOSE 8501
 CMD ["streamlit", "run", "app.py", "--server.address=0.0.0.0", "--server.port=8501"]

--- a/streamlit_app/README.md
+++ b/streamlit_app/README.md
@@ -8,4 +8,8 @@ pip install -r requirements.txt
 streamlit run app.py
 ```
 
-Ollama API のエンドポイントは環境変数 `OLLAMA_API_BASE_URL` で指定できます。Docker で実行する場合は `http://host.docker.internal:11435` が自動で設定され、ローカル実行時は `http://127.0.0.1:11435` が既定値となります。
+Ollama API への接続先は実行環境から自動で判定されます。
+Docker コンテナ内では `http://host.docker.internal:11435`、
+ローカル実行時は `http://127.0.0.1:11435` が既定値です。
+別のエンドポイントを利用したい場合のみ
+環境変数 `OLLAMA_API_BASE_URL` を設定してください。

--- a/streamlit_app/README.md
+++ b/streamlit_app/README.md
@@ -1,0 +1,11 @@
+# Streamlit アプリ
+
+Streamlit を用いた論文検索・可視化アプリです。別途起動している Ollama API と連携して動作します。
+
+## 実行方法
+```bash
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+Ollama API のエンドポイントは環境変数 `OLLAMA_API_BASE_URL` で指定できます。Docker で実行する場合は `http://host.docker.internal:11435` が自動で設定され、ローカル実行時は `http://127.0.0.1:11435` が既定値となります。

--- a/streamlit_app/api/ollama_api.py
+++ b/streamlit_app/api/ollama_api.py
@@ -8,7 +8,7 @@ def get_structured_response(model_name: str, prompt: str, temperature: float = 0
     Ollama の /api/generate エンドポイントを使い、指定したプロンプトで生成を実行します。
     非ストリーミングのため、レスポンス全体を一度に取得して辞書型に変換します。
     """
-    url_generate = f"{config.OLLAMA_API_BASE_URL}/api/generate"
+    url_generate = config.OLLAMA_GENERATE_URL
     data = {
         "model": model_name,
         "prompt": prompt,
@@ -68,7 +68,7 @@ def get_structured_response_v2(model_name: str, prompt: str, temperature: float 
     Returns:
         dict: 解析済みの構造化されたレスポンス
     """
-    url_chat = f"{config.OLLAMA_API_BASE_URL}/api/chat"  # エンドポイントをchatに変更
+    url_chat = config.OLLAMA_CHAT_URL  # エンドポイントをchatに変更
     payload = {
         "model": model_name,
         "messages": [{"role": "user", "content": prompt}],
@@ -130,7 +130,7 @@ def stream_chat_response(model_name: str, messages: list, temperature: float = 0
     Yields:
         response_text (str): 累積された応答テキスト（逐次更新）
     """
-    url_chat = f"{config.OLLAMA_API_BASE_URL}/api/chat"
+    url_chat = config.OLLAMA_CHAT_URL
     data = {
         "model": model_name,
         "messages": messages,

--- a/streamlit_app/utils/config.py
+++ b/streamlit_app/utils/config.py
@@ -17,6 +17,13 @@ default_ollama_url = (
     "http://host.docker.internal:11435" if running_in_docker() else "http://127.0.0.1:11435"
 )
 OLLAMA_API_BASE_URL = os.environ.get("OLLAMA_API_BASE_URL", default_ollama_url)
+# API エンドポイントの組み立てを一元化
+def get_ollama_url(path: str) -> str:
+    """Ollama API 用の完全な URL を返す"""
+    return f"{OLLAMA_API_BASE_URL}{path}"
+
+OLLAMA_CHAT_URL = get_ollama_url("/api/chat")
+OLLAMA_GENERATE_URL = get_ollama_url("/api/generate")
 #OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "deepseek-r1:8b-0528-qwen3-q8_0")
 _experiment_message_template = '''
 以下は論文の情報です。


### PR DESCRIPTION
## 変更内容
- `utils/config.py` に Ollama API URL を生成する関数と定数を追加
- `api/ollama_api.py` から重複していた URL 生成処理を削除し、上記定数を使用
- `streamlit_app/README.md` を新規追加
- `AGENTS.md` の構成ツリーに `streamlit_app/README.md` を追記
- プロジェクト構成を `pulling_files.py` で更新

## テスト結果
- `pytest -q` を実行し、テストが存在しないことを確認


------
https://chatgpt.com/codex/tasks/task_e_6844625cee04832cbb823c590532c8ad