### PR TITLE
検索結果ページの追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,17 +20,23 @@ paper_search/
 │       │   ├── favicon.ico
 │       │   ├── globals.css
 │       │   ├── layout.tsx
-│       │   └── page.tsx
-<<<<<<< HEAD
+│       │   ├── page.tsx
+│       │   └── search
+│       │       └── page.tsx
+│       ├── components
+│       │   └── PaperSearchApp.tsx
 │       ├── eslint.config.mjs
 │       ├── next.config.ts
 │       ├── postcss.config.mjs
-│       └── public
-│           ├── file.svg
-│           ├── globe.svg
-│           ├── next.svg
-│           ├── vercel.svg
-│           └── window.svg
+│       ├── public
+│       │   ├── file.svg
+│       │   ├── globe.svg
+│       │   ├── next.svg
+│       │   ├── vercel.svg
+│       │   └── window.svg
+│       ├── package.json
+│       ├── package-lock.json
+│       └── tsconfig.json
 ├── streamlit_app
 │   ├── Dockerfile
 │   ├── README.md
@@ -64,46 +70,11 @@ paper_search/
 │       ├── field_colors.py
 │       ├── llm_controller.py
 │       └── paper_controller.py
+├── temp
+│   └── paper-search-ui.tsx
 └── tools
     ├── project_tree.py
     └── pulling_files.py
-=======
-│       ├── components
-│       │   └── PaperSearchApp.tsx
-│       ├── package.json
-│       ├── package-lock.json
-│       ├── eslint.config.mjs
-│       ├── next.config.ts
-│       ├── postcss.config.mjs
-│       └── tsconfig.json
-└── streamlit_app
-    ├── Dockerfile
-    ├── README.md
-    ├── api
-    │   ├── lm_studio_api.py
-    │   ├── ollama_api.py
-    │   └── paper_api.py
-    ├── app.py
-    ├── core
-    │   ├── data_models.py
-    │   ├── llm_service.py
-    │   └── paper_service.py
-    ├── requirements.txt
-    ├── state
-    │   ├── state_manager.py
-    │   └── state_manager_back.py
-    ├── ui
-    │   ├── chat_panel.py
-    │   ├── paper_network.py
-    │   ├── result_summary.py
-    │   └── search_bar.py
-    └── utils
-        ├── config.py
-        ├── cytoscape_utils.py
-        ├── field_colors.py
-        ├── llm_controller.py
-        └── paper_controller.py
->>>>>>> codex/検索文字色を黒に変更
 ```
 
 新しいファイルやディレクトリを追加・削除した場合は、上記のツリーを必ず最新の状態に更新してください。構成の確認には `python tools/project_tree.py` を利用するとディレクトリ構成のみを簡潔に表示できます。詳細な一覧が必要な場合は `python tools/pulling_files.py` を実行してください。いずれのスクリプトも `.gitignore` と `.dockerignore` を参照して不要なファイルを除外します。

--- a/react_app/frontend/app/page.tsx
+++ b/react_app/frontend/app/page.tsx
@@ -1,5 +1,18 @@
-import PaperSearchApp from '../components/PaperSearchApp';
-
 export default function Home() {
-  return <PaperSearchApp />;
+  return (
+    <main className="p-6">
+      <h1 className="text-xl mb-4">論文検索</h1>
+      <form action="/search" method="get">
+        <input
+          type="text"
+          name="q"
+          placeholder="キーワードを入力"
+          className="border p-2 mr-2"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-3 py-2">
+          検索
+        </button>
+      </form>
+    </main>
+  );
 }

--- a/react_app/frontend/app/search/page.tsx
+++ b/react_app/frontend/app/search/page.tsx
@@ -1,0 +1,23 @@
+interface SearchPageProps {
+  searchParams: { q?: string };
+}
+
+export default async function SearchPage({ searchParams }: SearchPageProps) {
+  const query = searchParams.q ?? '';
+  const res = await fetch(
+    `https://example.com/api/search?q=${encodeURIComponent(query)}`
+  );
+  const results = await res.json();
+
+  return (
+    <main className="p-6">
+      <h1 className="text-xl mb-4">「{query}」の検索結果</h1>
+      {results.items.map((item: any) => (
+        <div key={item.id} className="mb-4 border-b pb-2">
+          <h2 className="text-lg">{item.title}</h2>
+          <p>{item.summary}</p>
+        </div>
+      ))}
+    </main>
+  );
+}


### PR DESCRIPTION
## 概要
- `/search` へのページ遷移に対応するため、検索結果ページを追加
- 検索トップページをフォームのみのシンプルな実装に変更
- `AGENTS.md` のプロジェクトツリーを更新

## テスト
- `pytest -q` を実行し `no tests ran` を確認

------
https://chatgpt.com/codex/tasks/task_e_6846c2bd702c832c9c97241a9d251c13