### PR TITLE
React フロントエンドとFastAPI連携追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,11 @@ paper_search/
 │   ├── backend
 │   │   ├── Dockerfile
 │   │   ├── README.md
+│   │   ├── __init__.py
 │   │   ├── main.py
-│   │   └── requirements.txt
+│   │   ├── models.py
+│   │   ├── requirements.txt
+│   │   └── services.py
 │   └── frontend
 │       ├── Dockerfile
 │       ├── README.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     ports:
       - "3000:3000"
     container_name: react_frontend
+    environment:
+      - NEXT_PUBLIC_API_URL=http://backend:8000
     depends_on:
       - backend
     volumes:

--- a/react_app/backend/main.py
+++ b/react_app/backend/main.py
@@ -16,3 +16,19 @@ async def health_check():
     """ヘルスチェック用エンドポイント"""
     return {"status": "ok"}
 
+
+from fastapi import Query
+
+from .services import fetch_papers_by_query
+
+
+@app.get("/papers")
+async def search_papers(
+    q: str = Query(..., description="検索クエリ"),
+    year_from: int = Query(2023, description="開始年"),
+    year_to: int | None = Query(None, description="終了年"),
+    limit: int = Query(10, description="取得件数"),
+):
+    """論文検索エンドポイント"""
+    result = fetch_papers_by_query(q, (year_from, year_to), limit)
+    return result

--- a/react_app/backend/models.py
+++ b/react_app/backend/models.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+class PaperInfo(BaseModel):
+    """単一論文の情報"""
+
+    title: str
+    abstract: Optional[str] = None
+    url: str
+    paper_id: str
+
+class PaperResult(BaseModel):
+    """論文検索結果"""
+
+    papers: List[PaperInfo] = []

--- a/react_app/backend/requirements.txt
+++ b/react_app/backend/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+requests

--- a/react_app/backend/services.py
+++ b/react_app/backend/services.py
@@ -1,0 +1,61 @@
+"""論文検索用のサービス関数群"""
+
+from typing import List, Tuple, Optional
+import time
+import requests
+
+from .models import PaperInfo, PaperResult
+
+
+def search_papers_semantic(
+    query: str,
+    year_from: int = 2023,
+    year_to: Optional[int] = None,
+    limit: int = 20,
+    max_retries: int = 10,
+) -> List[dict]:
+    """Semantic Scholar API から論文情報を取得する"""
+    url = "http://api.semanticscholar.org/graph/v1/paper/search/"
+    params = {
+        "query": query,
+        "fields": "title,abstract,url,publicationTypes",
+        "limit": limit,
+        "sort": "relevance",
+    }
+    if year_to is not None:
+        params["year"] = f"{year_from}-{year_to}"
+    else:
+        params["year"] = f"{year_from}-"
+
+    retries = 0
+    while retries < max_retries:
+        response = requests.get(url, params=params, timeout=10)
+        data = response.json()
+        if "data" in data:
+            return data["data"]
+        if data.get("code") == "429":
+            time.sleep(1)
+            retries += 1
+            continue
+        raise RuntimeError("API error: %s" % data)
+    raise RuntimeError("API rate limit exceeded")
+
+
+def fetch_papers_by_query(
+    query: str,
+    year_range: Tuple[int, Optional[int]],
+    limit: int = 10,
+) -> PaperResult:
+    """クエリから論文情報を取得し PaperResult に整形する"""
+    year_from, year_to = year_range
+    raw_papers = search_papers_semantic(query, year_from, year_to, limit)
+    papers = [
+        PaperInfo(
+            title=p["title"],
+            abstract=p.get("abstract"),
+            url=p["url"],
+            paper_id=p["paperId"],
+        )
+        for p in raw_papers
+    ]
+    return PaperResult(papers=papers)

--- a/react_app/frontend/README.md
+++ b/react_app/frontend/README.md
@@ -31,6 +31,8 @@ frontend:
   ports:
     - "3000:3000"
   container_name: react_frontend
+  environment:
+    - NEXT_PUBLIC_API_URL=http://backend:8000
   depends_on:
     - backend
   volumes:

--- a/react_app/frontend/components/ResultsPage.tsx
+++ b/react_app/frontend/components/ResultsPage.tsx
@@ -15,32 +15,12 @@ import {
 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 
-const mockResults = [
-  {
-    title: "Attention Is All You Need",
-    authors: "Vaswani, A., Shazeer, N., Parmar, N., et al.",
-    journal: "Advances in Neural Information Processing Systems",
-    year: "2017",
-    abstract:
-      "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks that include an encoder and a decoder. The best performing models also connect the encoder and decoder through an attention mechanism...",
-  },
-  {
-    title: "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding",
-    authors: "Devlin, J., Chang, M. W., Lee, K., Toutanova, K.",
-    journal: "NAACL-HLT",
-    year: "2019",
-    abstract:
-      "We introduce a new language representation model called BERT, which stands for Bidirectional Encoder Representations from Transformers. Unlike recent language representation models, BERT is designed to pre-train deep bidirectional...",
-  },
-  {
-    title: "Language Models are Few-Shot Learners",
-    authors: "Brown, T., Mann, B., Ryder, N., et al.",
-    journal: "Advances in Neural Information Processing Systems",
-    year: "2020",
-    abstract:
-      "Recent work has demonstrated substantial gains on many NLP tasks and benchmarks by pre-training on a large corpus of text followed by fine-tuning on a specific task. While typically task-agnostic in architecture...",
-  },
-];
+interface PaperInfo {
+  title: string;
+  abstract?: string;
+  url: string;
+  paper_id: string;
+}
 
 const ResultsPage: React.FC = () => {
   const params = useSearchParams();
@@ -49,6 +29,7 @@ const ResultsPage: React.FC = () => {
   const [sortOption, setSortOption] = useState<"relevance" | "date" | "citations">(
     "relevance"
   );
+  const [results, setResults] = useState<PaperInfo[]>([]);
   const [sortDropdownOpen, setSortDropdownOpen] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [headerHeight, setHeaderHeight] = useState(0);
@@ -64,6 +45,16 @@ const ResultsPage: React.FC = () => {
     window.addEventListener("resize", updateHeight);
     return () => window.removeEventListener("resize", updateHeight);
   }, []);
+
+  useEffect(() => {
+    const apiBase = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+    if (searchQuery) {
+      fetch(`${apiBase}/papers?q=${encodeURIComponent(searchQuery)}`)
+        .then((res) => res.json())
+        .then((data) => setResults(data.papers ?? []))
+        .catch((err) => console.error(err));
+    }
+  }, [searchQuery]);
 
   const handleSearch = () => {
     if (searchQuery.trim()) {
@@ -208,7 +199,7 @@ const ResultsPage: React.FC = () => {
                 </div>
               </div>
               <div className="space-y-4">
-                {mockResults.map((result, index) => (
+                {results.map((result, index) => (
                   <div
                     key={index}
                     className="bg-white p-6 rounded-lg border border-gray-200 hover:shadow-md transition-shadow cursor-pointer"
@@ -216,9 +207,6 @@ const ResultsPage: React.FC = () => {
                     <h3 className="text-lg font-normal text-blue-700 mb-2 hover:underline">
                       {result.title}
                     </h3>
-                    <p className="text-sm text-green-700 mb-2">
-                      {result.authors} - {result.journal}, {result.year}
-                    </p>
                     <p className="text-sm text-gray-700 leading-relaxed">
                       {result.abstract}
                     </p>


### PR DESCRIPTION
## 概要
- FastAPI バックエンドで論文検索API(`/papers`)を実装
- 検索用のモデル/サービスモジュールを追加
- backend の依存ライブラリに `requests` を追加
- React 結果画面から API を呼び出して検索結果を表示するよう更新
- `AGENTS.md` のプロジェクトツリーを更新

## テスト
- `pytest -q` を実行し `no tests ran` を確認

------
https://chatgpt.com/codex/tasks/task_e_6846fe311e04832c9eae511dca6efdaa