### PR TITLE
Fix logo navigation

### DIFF
--- a/react_app/frontend/components/AnalysisPanel.tsx
+++ b/react_app/frontend/components/AnalysisPanel.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { X, Brain, Languages } from "lucide-react";
 import { Paper, PaperAnalysisResult } from "../types";

--- a/react_app/frontend/components/PaperCard.tsx
+++ b/react_app/frontend/components/PaperCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Eye, Brain, Languages, BarChart3, Lightbulb } from "lucide-react";
 import { Paper, QuickSummary as QuickSummaryType, StreamingQuickSummary, SummaryData } from "../types";

--- a/react_app/frontend/features/search/ResultsHeader.tsx
+++ b/react_app/frontend/features/search/ResultsHeader.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { LoadingSpinner } from "../../ui";

--- a/react_app/frontend/features/search/SearchBar.tsx
+++ b/react_app/frontend/features/search/SearchBar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Search } from "lucide-react";
 

--- a/react_app/frontend/features/summary/DetailedSummary.tsx
+++ b/react_app/frontend/features/summary/DetailedSummary.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from "react";
 import { 
   X, 

--- a/react_app/frontend/features/summary/hooks/useSummary.ts
+++ b/react_app/frontend/features/summary/hooks/useSummary.ts
@@ -31,7 +31,7 @@ export const useSummary = () => {
     setIsQuickSummarizing(true);
     
     try {
-      const response = await fetch('/quick-summary', {
+      const response = await fetch(apiEndpoints.quickSummary, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/react_app/frontend/layout/Header.tsx
+++ b/react_app/frontend/layout/Header.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { forwardRef } from "react";
 import { Menu, FileText } from "lucide-react";
 import { SearchBar } from "../features/search";

--- a/react_app/frontend/layout/Sidebar.tsx
+++ b/react_app/frontend/layout/Sidebar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { User, Settings, Clock, Bookmark, TrendingUp } from "lucide-react";
 import { DRAWER_WIDTH } from "../config/constants";


### PR DESCRIPTION
## Summary
- Headerコンポーネントをはじめ、クリック操作を伴うUIをclient component化
- これによりヘッダーロゴクリックで検索画面に戻れるよう修正

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685145e97518832c8c6b7ec46bbadf62